### PR TITLE
Add BGGR support to image_processor.

### DIFF
--- a/python/hololink/operators/image_processor/image_processor.cpp
+++ b/python/hololink/operators/image_processor/image_processor.cpp
@@ -89,6 +89,8 @@ PYBIND11_MODULE(_image_processor, m)
     py::enum_<ImageProcessorOp::BayerFormat>(op, "BayerFormat")
         .value("RGGB", ImageProcessorOp::BayerFormat::RGGB,
             R"pbdoc(RGGB)pbdoc")
+        .value("BGGR", ImageProcessorOp::BayerFormat::BGGR,
+            R"pbdoc(BGGR)pbdoc")
         .value("GBRG", ImageProcessorOp::BayerFormat::GBRG,
             R"pbdoc(GBRG)pbdoc")
         .export_values();

--- a/src/hololink/operators/image_processor/image_processor.cpp
+++ b/src/hololink/operators/image_processor/image_processor.cpp
@@ -294,6 +294,12 @@ void ImageProcessorOp::start()
         x0y1_offset = 1; // G
         x1y1_offset = 2; // B
         break;
+    case BayerFormat::BGGR:
+        x0y0_offset = 2; // B
+        x1y0_offset = 1; // G
+        x0y1_offset = 1; // G
+        x1y1_offset = 0; // R
+        break;
     case BayerFormat::GBRG:
         x0y0_offset = 1; // G
         x1y0_offset = 2; // B

--- a/src/hololink/operators/image_processor/image_processor.hpp
+++ b/src/hololink/operators/image_processor/image_processor.hpp
@@ -38,6 +38,7 @@ public:
         INVALID = -1,
         // NOTE THAT THESE GUYS LINE UP WITH THE VALUES USED BY NPP; see
         // https://docs.nvidia.com/cuda/npp/nppdefs.html#c.NppiBayerGridPosition
+        BGGR = 0,
         RGGB = 1,
         GBRG = 2,
     };


### PR DESCRIPTION
This PR adds BGGR support to the `image_processor` operator to enable supporting image sensors that use a BGGR Bayer grid pattern (e.g., many OmniVision sensors).