### PR TITLE
Adjust phc2sys startup to wait until after ntpdate runs.

### DIFF
--- a/docs/user_guide/setup.md
+++ b/docs/user_guide/setup.md
@@ -166,7 +166,7 @@ Next, follow the directions on the appropriate tab below to configure your host 
   cat <<EOF | sudo tee $PHC2SYS_SERVICE >/dev/null
   [Unit]
   Description=Copy system time to $EN0
-  After=time-sync.target
+  After=timemaster.service
 
   [Service]
   Type=simple


### PR DESCRIPTION
For applications using PTP synchronization, the setup instructions show how to run phc2sys at startup, which is necessary to keep the hardware clock in the NIC synchronized with the system clock.  The setup instructions rely on the default ntpdate configuration to initialize the system clock with the current real-world time. Before, the suggested phc2sys startup script doesn't properly wait for ntpdate to complete, so that when ntpdate does finish, phc2sys sees a large jump in the system time.  Because phc2sys slowly adjusts the NIC clock, the time published by ptp4l will then not be synchronized with the system clock, and could take a very long time to do so.  This has the effect of publishing a time with ingress data that is out-of-sync with the system time.  This change request fixes the documentation to include a startup instruction that waits for ntpdate to finish before running phc2sys.

See issue https://github.com/nvidia-holoscan/holoscan-sensor-bridge/issues/4.