### PR TITLE
Add default values to Dockerfile "ARG" commands.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@
 ARG CONTAINER_TYPE=dgpu
 FROM nvcr.io/nvidia/clara-holoscan/holoscan:v2.3.0-${CONTAINER_TYPE}
 
-ARG CONTAINER_TYPE
+ARG CONTAINER_TYPE=invalid
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y -q \

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -15,7 +15,7 @@
 #
 # See README.md for detailed information.
 
-ARG CONTAINER_VERSION
+ARG CONTAINER_VERSION=invalid
 FROM ${CONTAINER_VERSION} AS base
 
 # build container

--- a/docs/Dockerfile.docs
+++ b/docs/Dockerfile.docs
@@ -1,7 +1,7 @@
 # The base image should be the development container
 # to provide all the runtime dependencies needed by
 # the python api doc generator
-ARG CONTAINER_VERSION
+ARG CONTAINER_VERSION=invalid
 FROM $CONTAINER_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This resolves a warning that is issued when building containers with docker version e.g. 27 or newer.  Assigning "invalid" to those args as default will result in a compile-time error (which doesn't happen because build scripts provide values for those arguments).

> InvalidDefaultArgInFrom: Default value for ARG ${CONTAINER_VERSION} results in empty or invalid base image name

See https://github.com/nvidia-holoscan/holoscan-sensor-bridge/issues/6.