### PR TITLE
support BGGR and GRBG bayer format in image_processor

### DIFF
--- a/python/hololink/operators/image_processor/image_processor.cpp
+++ b/python/hololink/operators/image_processor/image_processor.cpp
@@ -87,10 +87,14 @@ PYBIND11_MODULE(_image_processor, m)
                   .def("setup", &ImageProcessorOp::setup, "spec"_a);
 
     py::enum_<ImageProcessorOp::BayerFormat>(op, "BayerFormat")
+        .value("BGGR", ImageProcessorOp::BayerFormat::BGGR,
+            R"pbdoc(BGGR)pbdoc")
         .value("RGGB", ImageProcessorOp::BayerFormat::RGGB,
             R"pbdoc(RGGB)pbdoc")
         .value("GBRG", ImageProcessorOp::BayerFormat::GBRG,
             R"pbdoc(GBRG)pbdoc")
+        .value("GRBG", ImageProcessorOp::BayerFormat::GRBG,
+            R"pbdoc(GRBG)pbdoc")
         .export_values();
 
 } // PYBIND11_MODULE

--- a/src/hololink/operators/image_processor/image_processor.cpp
+++ b/src/hololink/operators/image_processor/image_processor.cpp
@@ -288,6 +288,12 @@ void ImageProcessorOp::start()
 
     uint32_t x0y0_offset, x1y0_offset, x0y1_offset, x1y1_offset;
     switch (BayerFormat(bayer_format_.get())) {
+    case BayerFormat::BGGR:
+        x0y0_offset = 2; // B
+        x1y0_offset = 1; // G
+        x0y1_offset = 1; // G
+        x1y1_offset = 0; // R
+        break;
     case BayerFormat::RGGB:
         x0y0_offset = 0; // R
         x1y0_offset = 1; // G
@@ -298,6 +304,12 @@ void ImageProcessorOp::start()
         x0y0_offset = 1; // G
         x1y0_offset = 2; // B
         x0y1_offset = 0; // R
+        x1y1_offset = 1; // G
+        break;
+    case BayerFormat::GRBG:
+        x0y0_offset = 1; // G
+        x1y0_offset = 0; // R
+        x0y1_offset = 2; // B
         x1y1_offset = 1; // G
         break;
     default:

--- a/src/hololink/operators/image_processor/image_processor.hpp
+++ b/src/hololink/operators/image_processor/image_processor.hpp
@@ -38,8 +38,10 @@ public:
         INVALID = -1,
         // NOTE THAT THESE GUYS LINE UP WITH THE VALUES USED BY NPP; see
         // https://docs.nvidia.com/cuda/npp/nppdefs.html#c.NppiBayerGridPosition
+        BGGR = 0,
         RGGB = 1,
         GBRG = 2,
+        GRBG = 3,
     };
 
     void setup(holoscan::OperatorSpec& spec) override;


### PR DESCRIPTION
Currently only RGGB and GBRG bayer formats are supported in image processor.
Add support of BGGR and GRBG bayer format which may be used by new sensors.