### PR TITLE
Download firmware files individually from NGC.

### DIFF
--- a/scripts/local_manifest.py
+++ b/scripts/local_manifest.py
@@ -34,7 +34,7 @@ def measure(filename):
             md5.update(chunk)
         print(f"name={filename} size={stat.st_size} {md5.hexdigest()=}")
         image = {
-            "content": filename,
+            "filename": filename,
             "size": stat.st_size,
             "md5": md5.hexdigest(),
         }
@@ -45,7 +45,7 @@ def main():
     parser.add_argument(
         "--version",
         required=True,
-        help="Componoent version (e.g. \"2402\")",
+        help="Component version (e.g. \"2402\")",
     )
     parser.add_argument(
         "--manifest",
@@ -89,20 +89,34 @@ def main():
     #
     hololink = {
         "archive": {
-            "type": "local",
             "version": version,
             "enrollment_date": now.isoformat(),
         },
+        "content": {
+        },
         "strategy": strategy,
     }
-    hololink_images = { }
+    images = [ ]
     if cpnx_file is not None:
-        hololink_images["cpnx"] = measure(cpnx_file)
+        content = measure(cpnx_file)
+        hololink["content"][cpnx_file] = measure(cpnx_file)
+        images.append({
+            "content": cpnx_file,
+            "context": "cpnx",
+        })
     if clnx_file is not None:
-        hololink_images["clnx"] = measure(clnx_file)
+        hololink["content"][clnx_file] = measure(clnx_file)
+        images.append({
+            "content": clnx_file,
+            "context": "clnx",
+        })
     if stratix_file is not None:
-        hololink_images["stratix"] = measure(stratix_file)
-    hololink["images"] = hololink_images
+        hololink["content"][stratix_file] = measure(stratix_file)
+        images.append({
+            "content": stratix_file,
+            "context": "stratix",
+        })
+    hololink["images"] = images
     # Write the metadata to the manifest file
     manifest = {
         "hololink": hololink,

--- a/scripts/manifest.yaml
+++ b/scripts/manifest.yaml
@@ -1,23 +1,29 @@
 hololink:
   archive:
-    enrollment_date: '2024-08-03T18:57:03.617479+00:00'
-    md5: c8679363c98c10cf6368743ab04221b6
-    type: zip
-    url: https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_sensor_bridge_fpga_ip/versions/2407/zip
+    enrollment_date: '2025-01-16T21:35:58.659160+00:00'
     version: '2407'
-  images:
-    clnx:
-      content: fpga_clnx_v2407.bit
+  content:
+    NVIDIA_RTL_License_Agreement.txt:
+      md5: e8c77cea2712a6e3883c49b063ebc816
+      size: 16929
+      url: https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/clara-holoscan/holoscan_sensor_bridge_fpga_ip/2407/files?redirect=true&path=NVIDIA_RTL_License_Agreement.txt
+    fpga_clnx_v2407.bit:
       md5: 673db16ede425bd77b313bfc40f82588
       size: 383843
-    cpnx:
-      content: fpga_cpnx_v2407.bit
+      url: https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/clara-holoscan/holoscan_sensor_bridge_fpga_ip/2407/files?redirect=true&path=fpga_clnx_v2407.bit
+    fpga_cpnx_v2407.bit:
       md5: 6ad1a7d71b12ff26bcf7541c80ddd16e
       size: 1960836
+      url: https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/clara-holoscan/holoscan_sensor_bridge_fpga_ip/2407/files?redirect=true&path=fpga_cpnx_v2407.bit
+    hololink-hdl.zip:
+      md5: 21de471e09dce015946bd11f02bcd2b6
+      size: 1294292
+      url: https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/clara-holoscan/holoscan_sensor_bridge_fpga_ip/2407/files?redirect=true&path=hololink-hdl.zip
+  images:
+  - content: fpga_clnx_v2407.bit
+    context: clnx
+  - content: fpga_cpnx_v2407.bit
+    context: cpnx
   licenses:
-  - name: NVIDIA_RTL_License_Agreement.txt
-  other_content:
-  - content: hololink-hdl.zip
-    md5: 21de471e09dce015946bd11f02bcd2b6
-    size: 1294292
+  - NVIDIA_RTL_License_Agreement.txt
   strategy: sensor_bridge_10


### PR DESCRIPTION
NGC APIs no longer allow downloading a ZIP of a specific project and version; so a modification is presented which downloads those files individually.