### PR TITLE
Pin the specific version of cuda-python.

### DIFF
--- a/docker/Dockerfile.test-package
+++ b/docker/Dockerfile.test-package
@@ -33,7 +33,7 @@ RUN apt-get update \
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb \
   && dpkg -i cuda-keyring_1.1-1_all.deb
 
-RUN pip3 install holoscan cuda-python
+RUN pip3 install holoscan==3.3.0 cuda-python==12.9.0
 
 ARG HOLOLINK_VERSION=invalid
 ARG ARCH=invalid

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,8 +79,8 @@ setuptools.setup(
         "build_ext": cmake_build_extension.BuildExtension,
     },
     install_requires=[
-        "cuda-python",
-        "nvtx",
+        "cuda-python==12.9.0",
+        "nvtx==0.2.13",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
The public version of cuda-python has moved to CUDA13 support, deprecating some of the APIs used by this system.  The build is updated to use cuda-python==12.9.0.