### PR TITLE
Programming older IMX477 boards fails on access to nonexistent PTP and VSYNC registers.

### DIFF
--- a/python/tools/polarfire_esb.py
+++ b/python/tools/polarfire_esb.py
@@ -211,6 +211,8 @@ def manual_enumeration(args):
         "sequence_number_checking": 0,
         "serial_number": "100",
         "fpga_uuid": "ed6a9292-debf-40ac-b603-a24e025309c1",
+        "vsync_enable": 0,
+        "ptp_enable": 0,
     }
     metadata = hololink_module.Metadata(m)
     hololink_module.DataChannel.use_data_plane_configuration(metadata, 0)


### PR DESCRIPTION
Recent metadata additions are used to skip initialization of PTP and VSYNC registers; make sure that "--force" on polarfire_hsb includes that as the older MPF200 2407 firmware doesn't have either facility.