### PR TITLE
Enable previously-skipped IMX477 tests.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ markers=
     skip_unless_ptp: Include PTP tests
     skip_unless_imx274: Marks tests as skip unless running with the "--imx274" command line switch
     skip_unless_imx477: Marks tests as skip unless running with the "--imx477" command line switch
+    skip_unless_stereo_imx477: Marks tests as skip unless running with the "--stereo-imx477" command line switch
     skip_unless_imx715: Marks tests as skip unless running with the "--imx715" command line switch
     skip_unless_igpu: Marks tests as skip unless running with the "--igpu" command line switch
     skip_unless_dgpu: Marks tests as skip unless running with the "--dgpu" command line switch

--- a/src/hololink/core/hololink.cpp
+++ b/src/hololink/core/hololink.cpp
@@ -939,6 +939,8 @@ public:
         const std::shared_ptr<Timeout>& in_timeout,
         bool ignore_nak) override
     {
+        HSB_LOG_DEBUG("i2c_transaction(peripheral_i2c_address={:#x}, write_byte.size={}, read_byte_count={}.",
+            peripheral_i2c_address, write_bytes.size(), read_byte_count);
         auto sequencer = hololink_.software_sequencer();
         auto [write_indexes, read_indexes, status_index] = encode_i2c_request(
             *sequencer, peripheral_i2c_address, write_bytes, read_byte_count);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,12 @@ def pytest_addoption(parser):
         help="Include tests for IMX477.",
     )
     parser.addoption(
+        "--stereo-imx477",
+        action="store_true",
+        default=False,
+        help="Include tests for Stereo IMX477.",
+    )
+    parser.addoption(
         "--imx715",
         action="store_true",
         default=False,
@@ -265,11 +271,22 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "skip_unless_ptp" in item.keywords:
                 item.add_marker(skip_ptp)
-    if not config.getoption("--imx477"):
-        skip_imx477 = pytest.mark.skip(reason="Tests only run in --imx477 mode.")
+    # --stereo-imx477 implies --imx477; but not the other way around
+    if not config.getoption("--imx477") and not config.getoption("--stereo-imx477"):
+        skip_imx477 = pytest.mark.skip(
+            reason="Tests only run in --imx477 or --stereo-imx477 mode."
+        )
         for item in items:
             if "skip_unless_imx477" in item.keywords:
                 item.add_marker(skip_imx477)
+    # but --imx477 does not imply --stereo-imx477
+    if not config.getoption("--stereo-imx477"):
+        skip_stereo_imx477 = pytest.mark.skip(
+            reason="Tests only run in --stereo-imx477 mode."
+        )
+        for item in items:
+            if "skip_unless_stereo_imx477" in item.keywords:
+                item.add_marker(skip_stereo_imx477)
     if not config.getoption("--hsb") and not config.getoption("--imx274"):
         skip_hsb = pytest.mark.skip(reason="Tests only run in --hsb mode.")
         for item in items:

--- a/tests/test_imx477_pattern.py
+++ b/tests/test_imx477_pattern.py
@@ -152,7 +152,6 @@ class PatternTestApplication(holoscan.core.Application):
         self._check_done()
 
 
-@pytest.mark.skip("IMX477 ISN'T SUPPORTED FOR 2501 FPGAs YET")
 @pytest.mark.skip_unless_imx477
 @pytest.mark.parametrize(
     "camera_mode,expected",

--- a/tests/test_imx477_timestamps.py
+++ b/tests/test_imx477_timestamps.py
@@ -204,7 +204,6 @@ class TimestampTestApplication(holoscan.core.Application):
 # time_limit, the acceptable amount of time between when the frame was sent and
 #   when we got around to looking at it, is much smaller in the RDMA
 #   configuration.
-@pytest.mark.skip("IMX477 ISN'T SUPPORTED FOR 2501 FPGAs YET")
 @pytest.mark.skip_unless_ptp
 @pytest.mark.skip_unless_imx477
 @pytest.mark.accelerated_networking

--- a/tests/test_linux_tao_peoplenet_imx477.py
+++ b/tests/test_linux_tao_peoplenet_imx477.py
@@ -25,7 +25,6 @@ import pytest
 from examples import linux_tao_peoplenet_imx477
 
 
-@pytest.mark.skip("IMX477 ISN'T SUPPORTED FOR 2501 FPGAs YET")
 @pytest.mark.skip_unless_imx477
 @pytest.mark.parametrize(
     "camera_mode",  # noqa: E501

--- a/tests/test_single_network_stereo_imx477_player.py
+++ b/tests/test_single_network_stereo_imx477_player.py
@@ -25,7 +25,7 @@ from examples import (
 )
 
 
-@pytest.mark.skip_unless_imx477
+@pytest.mark.skip_unless_stereo_imx477
 def test_single_network_linux_stereo_imx477_player(headless, frame_limit, capsys):
     arguments = [
         sys.argv[0],

--- a/tests/test_stereo_imx477_player.py
+++ b/tests/test_stereo_imx477_player.py
@@ -23,8 +23,7 @@ import pytest
 from examples import stereo_imx477_player
 
 
-@pytest.mark.skip("IMX477 ISN'T SUPPORTED FOR 2501 FPGAs YET")
-@pytest.mark.skip_unless_imx477
+@pytest.mark.skip_unless_stereo_imx477
 @pytest.mark.accelerated_networking
 @pytest.mark.parametrize(
     "camera_mode",  # noqa: E501


### PR DESCRIPTION
Many IMX477 tests were being skipped due to antique FPGA incompatibilities; those are now resolved.  Also, "--stereo-imx477" is added to filter out tests which rely on both IMX477s being populated; indicating "--stereo-imx477" also enables all tests that "--imx477" enabled.