### PR TITLE
Fix the holoscan SDK to v3.5.1 as newly released v3.6.1 is failing to compile.

### DIFF
--- a/docs/user_guide/thor-jp7-setup.md
+++ b/docs/user_guide/thor-jp7-setup.md
@@ -20,9 +20,8 @@ the following steps are required:
 - Install Holoscan SDK v3.5.1
 
 ```none
-  echo "deb https://repo.download.nvidia.com/jetson/jetson-4fed1671 r38.1 main" | sudo tee /etc/apt/sources.list.d/nvidia-l4t-apt-source-jpea.list
   sudo apt update
-  sudo apt install holoscan
+  sudo apt install holoscan=3.5.1
 ```
 
 - Install other Holoscan sensor bridge dependencies:


### PR DESCRIPTION
Current host setup instructions ask users to install the latest version of holoscan; newly release 3.6.1 fails on Thor JP7.0 configurations; so an update is provided showing how to work with 3.5.1.