### PR TITLE
fix: use hololink_SOURCE_DIR in emulation for FetchContent compatibility

### DIFF
--- a/src/hololink/emulation/CMakeLists.txt
+++ b/src/hololink/emulation/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
     set(HSB_EMULATOR_CUPY OFF)
     set(HSB_EMULATOR_BUILD_PYTHON ${HOLOLINK_BUILD_PYTHON})
     set(HSB_EMULATOR_TOT_BUILD TRUE)
-    set(HOLOLINK_REL_PATH "${CMAKE_SOURCE_DIR}")
+    set(HOLOLINK_REL_PATH "${hololink_SOURCE_DIR}")
 endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
 


### PR DESCRIPTION
Fix `HOLOLINK_REL_PATH` in `src/hololink/emulation/CMakeLists.txt` to use `${hololink_SOURCE_DIR}` instead of `${CMAKE_SOURCE_DIR}`: when consumed via CMake FetchContent, `CMAKE_SOURCE_DIR` points to the consuming project, breaking the include path for `hololink_deps/dlpack.cmake`

The top-level `CMakeLists.txt` was already fixed in 2.6.0-EA; this fixes the remaining occurrence in the emulation subsystem