### PR TITLE
fix: add static to SPI constexpr to fix unity build redefinitions

### DIFF
--- a/src/hololink/core/hololink.cpp
+++ b/src/hololink/core/hololink.cpp
@@ -40,14 +40,14 @@
 namespace hololink {
 
 // SPI control flags
-constexpr uint32_t SPI_START = 0b0000'0000'0000'0001;
+static constexpr uint32_t SPI_START = 0b0000'0000'0000'0001;
 // SPI status flags
-constexpr uint32_t SPI_BUSY = 0b0000'0000'0000'0001;
+static constexpr uint32_t SPI_BUSY = 0b0000'0000'0000'0001;
 [[maybe_unused]] constexpr uint32_t SPI_FSM_ERR = 0b0000'0000'0000'0010;
-constexpr uint32_t SPI_DONE = 0b0000'0000'0001'0000;
+static constexpr uint32_t SPI_DONE = 0b0000'0000'0001'0000;
 // SPI_CFG
-constexpr uint32_t SPI_CFG_CPOL = 0b0000'0000'0001'0000;
-constexpr uint32_t SPI_CFG_CPHA = 0b0000'0000'0010'0000;
+static constexpr uint32_t SPI_CFG_CPOL = 0b0000'0000'0001'0000;
+static constexpr uint32_t SPI_CFG_CPHA = 0b0000'0000'0010'0000;
 
 // uart registers
 //  address Ranges:

--- a/src/hololink/core/traditional_spi.cpp
+++ b/src/hololink/core/traditional_spi.cpp
@@ -25,11 +25,11 @@
 namespace hololink {
 
 // SPI control flags
-constexpr uint32_t SPI_START = 0b0000'0000'0000'0001;
-constexpr uint32_t SPI_BUSY = 0b0000'0001'0000'0000;
+static constexpr uint32_t SPI_START = 0b0000'0000'0000'0001;
+static constexpr uint32_t SPI_BUSY = 0b0000'0001'0000'0000;
 // SPI_CFG
-constexpr uint32_t SPI_CFG_CPOL = 0b0000'0000'0001'0000;
-constexpr uint32_t SPI_CFG_CPHA = 0b0000'0000'0010'0000;
+static constexpr uint32_t SPI_CFG_CPOL = 0b0000'0000'0001'0000;
+static constexpr uint32_t SPI_CFG_CPHA = 0b0000'0000'0010'0000;
 
 class TraditionalSpi
     : public Hololink::Spi {


### PR DESCRIPTION
`hololink.cpp` and `traditional_spi.cpp` both define `SPI_START`, `SPI_BUSY`, `SPI_CFG_CPOL`, `SPI_CFG_CPHA` at namespace scope with intentionally different values (different hardware register layouts). In unity (jumbo) builds these TUs are merged, causing redefinition errors

Add `static` to make internal linkage explicit — no-op for normal builds (constexpr at namespace scope already has internal linkage in C++17+) but fixes unity builds.