### PR TITLE
Added FPGA IP Source pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ including instructions for setup on
 configurations. Please see the user guide for host configuration and instructions on
 running unit tests.
 
+## FPGA IP Source Files
+
+The FPGA IP source code for the Holoscan sensor bridge is available at the following
+link:
+[FPGA IP Source](https://edge.urm.nvidia.com/artifactory/sw-holoscan-thirdparty-generic-local/hsb/fpga_ip/)
+
 ## Troubleshooting
 
 Be sure and check the


### PR DESCRIPTION
Updated the README file to point to FPGA source code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new "FPGA IP Source Files" section to the README with a direct link to the Holoscan sensor bridge FPGA IP source code, enabling easier access to relevant source materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->