### PR TITLE
Docker: Pin to CMake < 3.31.12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -245,6 +245,8 @@ RUN ${APT_CACHE_MOUNT} \
 # iputils-ping gives us the "ping" command
 # iproute2 gives us the "ip" command
 # For Holoviz: vulkan-tools, glslang-tools, vulkan-validationlayers, libvulkan-dev
+#
+# Pin to CMake 3.31.11 to work around 3.31.12 installation error (CMake Issue#27775).
 RUN ${APT_CACHE_MOUNT} apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
     # Container tools
@@ -260,8 +262,8 @@ RUN ${APT_CACHE_MOUNT} apt-get update \
     iproute2 \
     # Build tools
     build-essential \
-    cmake="3.31.*" \
-    cmake-data="3.31.*" \
+    cmake="3.31.11*" \
+    cmake-data="3.31.11*" \
     ninja-build \
     pkg-config \
     # Development libraries


### PR DESCRIPTION
Issue: CMake >= 3.31.12 APT package installation fails due to newly introduced "Breaks" field

Workaround: Pin CMake installation to 3.31.11 to unblock the container build

Tracking: https://gitlab.kitware.com/cmake/cmake/-/work_items/27775