### PR TITLE
Docker: Pin demo container to TensorRT 10

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -62,7 +62,7 @@ RUN ${APT_CACHE_MOUNT} apt-get update \
     && apt-get install -y \
         python3-requests \
         python3-yaml \
-        libnvinfer-bin \
+        libnvinfer-bin="10.*" \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the HoloLink Python wheel built above


### PR DESCRIPTION
Pin to TensorRT-10 as -11 has been recently released and has not yet passed QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TensorRT dependency version pinning in the demo image to ensure consistent builds with version 10.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->