### PR TITLE
Add fusa_coe_test_sensor_receiver example and TestSensor emulator

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -127,6 +127,19 @@ if(HOLOLINK_BUILD_FUSA)
     )
 
   list(APPEND EXAMPLE_INSTALL_TARGETS fusa_coe_vb1940_player)
+
+  add_executable(fusa_coe_test_sensor_receiver
+    fusa_coe_test_sensor_receiver.cpp
+    )
+
+  target_link_libraries(fusa_coe_test_sensor_receiver
+    PRIVATE
+      hololink
+      hololink::operators::fusa_coe_capture
+      holoscan::core
+    )
+
+  list(APPEND EXAMPLE_INSTALL_TARGETS fusa_coe_test_sensor_receiver)
 endif() # HOLOLINK_BUILD_FUSA
 
 if(HOLOLINK_BUILD_ROCE)

--- a/examples/fusa_coe_test_sensor_receiver.cpp
+++ b/examples/fusa_coe_test_sensor_receiver.cpp
@@ -1,0 +1,385 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief Receive generic test frames over Fusa CoE from a remote TestSensor emulator.
+ *
+ * Start the emulator on another host first, for example:
+ *   serve_coe_test_data <emulator_ip>
+ *
+ * Then run this application to configure the TestSensor over I2C and print received
+ * frame bytes to stdout.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include <holoscan/holoscan.hpp>
+
+#include <hololink/common/cuda_helper.hpp>
+#include <hololink/common/holoargs.hpp>
+#include <hololink/core/data_channel.hpp>
+#include <hololink/core/enumerator.hpp>
+#include <hololink/core/hololink.hpp>
+#include <hololink/core/logging.hpp>
+#include <hololink/core/networking.hpp>
+#include <hololink/core/serializer.hpp>
+#include <hololink/operators/fusa_coe_capture/fusa_coe_capture.hpp>
+
+// These constants must match the definitions in hololink::emulation::sensors::TestSensor
+static constexpr uint8_t TEST_I2C_ADDRESS = 0x5A;
+static constexpr uint16_t DEVICE_ID_REG = 0x0000u;
+static constexpr uint16_t FRAME_SIZE_REG = 0x0010u;
+static constexpr uint16_t PATTERN_MODE_REG = 0x0014u;
+static constexpr uint16_t CONSTANT_BYTE_REG = 0x0015u;
+static constexpr uint16_t FRAME_RATE_REG = 0x0020u;
+static constexpr uint16_t STREAMING_REG = 0x0030u;
+static constexpr uint16_t STATUS_REG = 0x0031u;
+
+enum class TestPatternMode : uint8_t {
+    CONSTANT = 0,
+    INCREMENTING = 1,
+};
+
+namespace {
+
+hololink::core::MacAddress parse_mac_address(const std::string& mac_str)
+{
+    hololink::core::MacAddress mac;
+    std::istringstream iss(mac_str);
+    std::string byte_str;
+    int i = 0;
+
+    while (std::getline(iss, byte_str, ':')) {
+        if (i >= 6)
+            throw std::invalid_argument("Too many bytes in MAC address");
+
+        if (byte_str.size() != 2)
+            throw std::invalid_argument("Each byte must be exactly two hex digits");
+
+        uint16_t byte;
+        std::istringstream hex_stream(byte_str);
+        hex_stream >> std::hex >> byte;
+        if (hex_stream.fail())
+            throw std::invalid_argument("Invalid hex in MAC address");
+
+        mac[i++] = static_cast<uint8_t>(byte);
+    }
+
+    if (i != 6)
+        throw std::invalid_argument("MAC address must have exactly 6 bytes");
+
+    return mac;
+}
+
+class TestSensorController {
+public:
+    TestSensorController(std::shared_ptr<hololink::Hololink::I2c> i2c)
+        : i2c_(std::move(i2c))
+    {
+    }
+
+    void write_register_u8(uint16_t reg, uint8_t value)
+    {
+        std::vector<uint8_t> write_bytes(3);
+        hololink::core::Serializer serializer(write_bytes.data(), write_bytes.size());
+        serializer.append_uint16_be(reg);
+        serializer.append_uint8(value);
+        i2c_->i2c_transaction(TEST_I2C_ADDRESS, write_bytes, 0);
+    }
+
+    void write_register_u32_le(uint16_t reg, uint32_t value)
+    {
+        std::vector<uint8_t> write_bytes(6);
+        hololink::core::Serializer serializer(write_bytes.data(), write_bytes.size());
+        serializer.append_uint16_be(reg);
+        serializer.append_uint8(static_cast<uint8_t>(value));
+        serializer.append_uint8(static_cast<uint8_t>(value >> 8));
+        serializer.append_uint8(static_cast<uint8_t>(value >> 16));
+        serializer.append_uint8(static_cast<uint8_t>(value >> 24));
+        i2c_->i2c_transaction(TEST_I2C_ADDRESS, write_bytes, 0);
+    }
+
+    void configure(uint32_t frame_size_bytes, uint32_t frame_rate_hz, uint8_t pattern_mode, uint8_t constant_byte)
+    {
+        write_register_u32_le(FRAME_SIZE_REG, frame_size_bytes);
+        write_register_u8(PATTERN_MODE_REG, pattern_mode);
+        write_register_u8(CONSTANT_BYTE_REG, constant_byte);
+        write_register_u32_le(FRAME_RATE_REG, frame_rate_hz);
+    }
+
+    void start_streaming()
+    {
+        write_register_u8(STREAMING_REG, 1);
+    }
+
+    void stop_streaming()
+    {
+        write_register_u8(STREAMING_REG, 0);
+    }
+
+private:
+    std::shared_ptr<hololink::Hololink::I2c> i2c_;
+};
+
+class FrameDataPrinterOp : public holoscan::Operator {
+public:
+    HOLOSCAN_OPERATOR_FORWARD_ARGS(FrameDataPrinterOp)
+
+    void setup(holoscan::OperatorSpec& spec) override
+    {
+        spec.input<holoscan::gxf::Entity>("input");
+        spec.param(frame_size_bytes_, "frame_size_bytes", "FrameSizeBytes",
+            "Number of payload bytes to print per frame", 256u);
+        spec.param(print_max_bytes_, "print_max_bytes", "PrintMaxBytes",
+            "Maximum number of bytes to print per frame (0 = all)", 64u);
+    }
+
+    void start() override
+    {
+        CudaCheck(cuInit(0));
+        CudaCheck(cuDeviceGet(&cuda_device_, 0));
+        CudaCheck(cuDevicePrimaryCtxRetain(&cuda_context_, cuda_device_));
+    }
+
+    void stop() override
+    {
+        if (cuda_context_) {
+            CudaCheck(cuDevicePrimaryCtxRelease(cuda_device_));
+            cuda_context_ = nullptr;
+        }
+    }
+
+    void compute(holoscan::InputContext& op_input, holoscan::OutputContext& op_output,
+        holoscan::ExecutionContext& context) override
+    {
+        (void)op_output;
+        (void)context;
+
+        hololink::common::CudaContextScopedPush scoped_cuda_context(cuda_context_);
+
+        auto maybe_entity = op_input.receive<holoscan::gxf::Entity>("input");
+        if (!maybe_entity) {
+            HOLOSCAN_LOG_WARN("Failed to receive entity");
+            return;
+        }
+
+        auto& entity = static_cast<nvidia::gxf::Entity&>(maybe_entity.value());
+        const auto maybe_tensor = entity.get<nvidia::gxf::Tensor>();
+        if (!maybe_tensor) {
+            throw std::runtime_error("Tensor not found in message");
+        }
+
+        const auto tensor = maybe_tensor.value();
+        if (tensor->storage_type() != nvidia::gxf::MemoryStorageType::kDevice) {
+            throw std::runtime_error("Expected device memory tensor from FusaCoeCaptureOp");
+        }
+
+        const uint32_t frame_size = tensor->size();
+        const uint32_t print_count = print_max_bytes_.get() == 0
+            ? frame_size
+            : std::min(frame_size, print_max_bytes_.get());
+
+        std::vector<uint8_t> host_data(print_count);
+        CudaCheck(cuMemcpyDtoH(host_data.data(),
+            reinterpret_cast<CUdeviceptr>(tensor->pointer()),
+            print_count));
+
+        frame_count_++;
+        int64_t frame_number = metadata()->get<int64_t>("frame_number");
+
+        std::cout << "Frame " << frame_count_;
+        if (frame_number >= 0) {
+            std::cout << " (metadata frame_number=" << frame_number << ")";
+        }
+        std::cout << " bytes[" << print_count << "/" << frame_size << "]:";
+
+        std::cout << std::hex << std::setfill('0');
+        for (uint32_t i = 0; i < print_count; ++i) {
+            if (i % 16 == 0) {
+                std::cout << '\n'
+                          << "    " << std::setw(4) << i << ": ";
+            }
+            std::cout << std::setw(2) << static_cast<unsigned>(host_data[i]) << ' ';
+        }
+        std::cout << std::dec << std::setfill(' ') << std::endl;
+    }
+
+private:
+    holoscan::Parameter<uint32_t> frame_size_bytes_;
+    holoscan::Parameter<uint32_t> print_max_bytes_;
+    CUdevice cuda_device_ = 0;
+    CUcontext cuda_context_ = nullptr;
+    uint64_t frame_count_ = 0;
+};
+
+class Application : public holoscan::Application {
+public:
+    Application(
+        const std::string& interface,
+        const hololink::core::MacAddress& mac,
+        hololink::DataChannel& hololink_channel,
+        std::shared_ptr<TestSensorController> test_sensor,
+        uint32_t frame_size_bytes,
+        uint32_t print_max_bytes,
+        uint32_t timeout_ms,
+        int frame_limit)
+        : interface_(interface)
+        , mac_(mac)
+        , hololink_channel_(hololink_channel)
+        , test_sensor_(std::move(test_sensor))
+        , frame_size_bytes_(frame_size_bytes)
+        , print_max_bytes_(print_max_bytes)
+        , timeout_ms_(timeout_ms)
+        , frame_limit_(frame_limit)
+    {
+        enable_metadata(true);
+    }
+
+    void compose() override
+    {
+        using namespace holoscan;
+
+        std::shared_ptr<Condition> condition;
+        if (frame_limit_ > 0) {
+            condition = make_condition<CountCondition>("count", frame_limit_);
+        } else {
+            condition = make_condition<BooleanCondition>("ok", true);
+        }
+
+        auto fusa_coe_capture = make_operator<hololink::operators::FusaCoeCaptureOp>(
+            "fusa_coe_capture",
+            Arg("interface", interface_),
+            Arg("mac_addr", std::vector<uint8_t>(mac_.begin(), mac_.end())),
+            Arg("hololink_channel", &hololink_channel_),
+            Arg("out_tensor_name", std::string("frame")),
+            Arg("timeout", timeout_ms_),
+            Arg("device_start", std::function<void()>([this] { test_sensor_->start_streaming(); })),
+            Arg("device_stop", std::function<void()>([this] { test_sensor_->stop_streaming(); })),
+            condition);
+        fusa_coe_capture->configure_frame_size(frame_size_bytes_);
+
+        auto frame_printer = make_operator<FrameDataPrinterOp>(
+            "frame_printer",
+            Arg("frame_size_bytes", frame_size_bytes_),
+            Arg("print_max_bytes", print_max_bytes_),
+            condition);
+
+        add_flow(fusa_coe_capture, frame_printer, { { "output", "input" } });
+    }
+
+private:
+    std::string interface_;
+    hololink::core::MacAddress mac_;
+    hololink::DataChannel& hololink_channel_;
+    std::shared_ptr<TestSensorController> test_sensor_;
+    uint32_t frame_size_bytes_;
+    uint32_t print_max_bytes_;
+    uint32_t timeout_ms_;
+    int frame_limit_;
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    using namespace hololink::args;
+
+    hololink::logging::hsb_log_level = hololink::logging::HSB_LOG_LEVEL_INFO;
+
+    OptionsDescription options_description("fusa_coe_test_sensor_receiver options");
+    // clang-format off
+    options_description.add_options()
+        ("hololink", value<std::string>()->default_value("192.168.0.2"), "IP address of Hololink board")
+        ("sensor", value<uint32_t>()->default_value(0), "Sensor index (I2C bus = CAM_I2C_BUS + sensor)")
+        ("frame-size", value<uint32_t>()->default_value(256), "Test frame payload size in bytes")
+        ("frame-rate", value<uint32_t>()->default_value(30), "TestSensor frame rate in Hz")
+        ("pattern-mode", value<uint32_t>()->default_value(static_cast<uint32_t>(TestPatternMode::INCREMENTING)),
+            "TestSensor pattern mode (0=constant, 1=incrementing)")
+        ("constant-byte", value<uint32_t>()->default_value(0xA5), "Constant pattern byte when pattern-mode=0")
+        ("frame-limit", value<int>()->default_value(10), "Exit after receiving this many frames (0=infinite, default=10)")
+        ("print-max-bytes", value<uint32_t>()->default_value(64), "Max bytes to print per frame (0=all)")
+        ("timeout", value<uint32_t>()->default_value(1500), "Capture timeout in milliseconds")
+        ;
+    // clang-format on
+
+    try {
+        auto variables_map = Parser().parse_command_line(argc, argv, options_description);
+        const auto hololink_ip = variables_map["hololink"].as<std::string>();
+        const auto sensor = variables_map["sensor"].as<uint32_t>();
+        const auto frame_size = variables_map["frame-size"].as<uint32_t>();
+        const auto frame_rate = variables_map["frame-rate"].as<uint32_t>();
+        const auto pattern_mode = static_cast<uint8_t>(variables_map["pattern-mode"].as<uint32_t>());
+        const auto constant_byte = static_cast<uint8_t>(variables_map["constant-byte"].as<uint32_t>());
+        const auto frame_limit = variables_map["frame-limit"].as<int>();
+        const auto print_max_bytes = variables_map["print-max-bytes"].as<uint32_t>();
+        const auto timeout_ms = variables_map["timeout"].as<uint32_t>();
+
+        if (frame_size == 0) {
+            throw std::invalid_argument("frame-size must be greater than 0");
+        }
+        if (pattern_mode != static_cast<uint8_t>(TestPatternMode::CONSTANT)
+            && pattern_mode != static_cast<uint8_t>(TestPatternMode::INCREMENTING)) {
+            throw std::invalid_argument("pattern-mode must be 0 (constant) or 1 (incrementing)");
+        }
+
+        auto channel_metadata = hololink::Enumerator::find_channel(hololink_ip);
+        hololink::Metadata metadata(channel_metadata);
+        hololink::DataChannel::use_sensor(metadata, sensor);
+        hololink::DataChannel hololink_channel(metadata);
+
+        auto interface = metadata.get<std::string>("interface").value_or("");
+        auto mac_str = metadata.get<std::string>("mac_id").value_or("");
+        auto mac_bytes = parse_mac_address(mac_str);
+        HOLOSCAN_LOG_INFO("Using interface={}, mac={}", interface, mac_str);
+
+        std::shared_ptr<hololink::Hololink> hololink = hololink_channel.hololink();
+        hololink->start();
+        hololink->reset();
+
+        auto i2c = hololink->get_i2c(hololink::CAM_I2C_BUS + sensor);
+        auto test_sensor = std::make_shared<TestSensorController>(i2c);
+        test_sensor->configure(frame_size, frame_rate, pattern_mode, constant_byte);
+
+        HOLOSCAN_LOG_INFO(
+            "Configured TestSensor: frame_size={}, frame_rate={} Hz, pattern_mode={}, constant_byte=0x{:02x}",
+            frame_size, frame_rate, static_cast<unsigned>(pattern_mode), constant_byte);
+        HOLOSCAN_LOG_INFO("Ensure serve_coe_test_data is running on the emulator host");
+
+        auto app = std::make_unique<Application>(
+            interface,
+            mac_bytes,
+            hololink_channel,
+            test_sensor,
+            frame_size,
+            print_max_bytes,
+            timeout_ms,
+            frame_limit);
+        app->run();
+
+        hololink->stop();
+        return 0;
+    } catch (const std::exception& e) {
+        HOLOSCAN_LOG_ERROR("Application failed: {}", e.what());
+        return -1;
+    }
+}

--- a/src/hololink/emulation/examples/CMakeLists.txt
+++ b/src/hololink/emulation/examples/CMakeLists.txt
@@ -156,6 +156,24 @@ if (CUDAToolkit_FOUND)
         CUDA::cudart
     )
     
+    add_executable(serve_coe_test_data
+        serve_coe_test_data.cpp
+    )
+    set_target_properties(serve_coe_test_data PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+    target_include_directories(serve_coe_test_data PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../..
+        ${CUDAToolkit_INCLUDE_DIRS}
+    )
+
+    target_link_libraries(serve_coe_test_data PRIVATE
+        hololink::emulation
+        hololink::emulation::coe
+        hololink::emulation::sensors
+        emulator_utils
+        CUDA::cudart
+    )
+
     add_executable(serve_coe_stereo_vb1940_frames
         serve_coe_stereo_vb1940_frames.cpp
     )

--- a/src/hololink/emulation/examples/emulator_utils.cu
+++ b/src/hololink/emulation/examples/emulator_utils.cu
@@ -178,7 +178,8 @@ void sleep_frame_rate(struct timespec* frame_start_time, struct LoopConfig& loop
         delta_sec--;
         delta_nsec += NS_PER_SEC;
     }
-    int delta_ms = static_cast<int>(MS_PER_SEC / loop_config.frame_rate_per_second - MS_PER_SEC * (delta_sec + delta_nsec * SEC_PER_NS));
+    auto frames_per_second = std::max(loop_config.frame_rate_per_second, 1u);
+    int delta_ms = static_cast<int>(MS_PER_SEC / frames_per_second - MS_PER_SEC * (delta_sec + delta_nsec * SEC_PER_NS));
     if (delta_ms > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(delta_ms));
     }
@@ -408,5 +409,96 @@ void loop_stereo_vb1940(struct LoopConfig& loop_config, sensors::Vb1940Emulator&
         }
         
         sleep_frame_rate(&frame_start_time, loop_config);
+    }
+}
+
+void generate_test_frame(DLTensor& frame_data, sensors::TestSensor& test_sensor, uint64_t frame_index)
+{
+    const bool is_gpu = frame_data.device.device_type == kDLCUDA;
+    if (frame_data.data) {
+        if (is_gpu) {
+            cudaFree(frame_data.data);
+        } else {
+            delete[] static_cast<uint8_t*>(frame_data.data);
+        }
+        frame_data.data = nullptr;
+    }
+
+    const uint32_t frame_size = test_sensor.get_frame_size();
+    if (frame_size == 0) {
+        frame_data.shape[0] = 0;
+        return;
+    }
+
+    uint8_t* host_data = new uint8_t[frame_size];
+    test_sensor.fill_frame(host_data, frame_index);
+
+    if (is_gpu) {
+        uint8_t* gpu_data = nullptr;
+        cudaError_t error = cudaMalloc(&gpu_data, frame_size);
+        if (error != cudaSuccess) {
+            delete[] host_data;
+            throw std::runtime_error("CUDA allocation failed for test frame: " + std::string(cudaGetErrorString(error)));
+        }
+        error = cudaMemcpy(gpu_data, host_data, frame_size, cudaMemcpyHostToDevice);
+        delete[] host_data;
+        if (error != cudaSuccess) {
+            cudaFree(gpu_data);
+            throw std::runtime_error("CUDA Memcpy failed for test frame: " + std::string(cudaGetErrorString(error)));
+        }
+        frame_data.data = gpu_data;
+    } else {
+        frame_data.data = host_data;
+    }
+    frame_data.shape[0] = static_cast<int64_t>(frame_size);
+}
+
+void loop_single_test(struct LoopConfig& loop_config, sensors::TestSensor& test_sensor, DataPlane& data_plane, DLTensor& frame_data)
+{
+    bool streaming = false;
+    unsigned int frame_count = 0;
+    uint64_t frame_index = 0;
+    while (!loop_config.num_frames || (frame_count < loop_config.num_frames)) {
+        struct timespec frame_start_time;
+        clock_gettime(CLOCK_MONOTONIC, &frame_start_time);
+
+        if (!streaming && test_sensor.is_streaming()) {
+            streaming = true;
+            generate_test_frame(frame_data, test_sensor, frame_index);
+        } else if (!test_sensor.is_streaming()) {
+            streaming = false;
+        }
+
+        if (streaming) {
+            const int64_t expected_size = static_cast<int64_t>(test_sensor.get_frame_size());
+            if (frame_data.shape[0] != expected_size) {
+                generate_test_frame(frame_data, test_sensor, frame_index);
+            } else {
+                if (frame_data.device.device_type == kDLCUDA) {
+                    uint8_t* host_data = new uint8_t[expected_size];
+                    test_sensor.fill_frame(host_data, frame_index);
+                    cudaError_t error = cudaMemcpy(frame_data.data, host_data, expected_size, cudaMemcpyHostToDevice);
+                    delete[] host_data;
+                    if (error != cudaSuccess) {
+                        throw std::runtime_error("CUDA Memcpy failed for test frame: " + std::string(cudaGetErrorString(error)));
+                    }
+                } else {
+                    test_sensor.fill_frame(static_cast<uint8_t*>(frame_data.data), frame_index);
+                }
+            }
+
+            const int64_t sent_bytes = data_plane.send(frame_data);
+            if (sent_bytes < 0) {
+                throw std::runtime_error("Error sending data: " + std::to_string(errno) + " " + std::string(strerror(errno)));
+            }
+            if (sent_bytes > 0) {
+                frame_count++;
+                frame_index++;
+            }
+        }
+
+        LoopConfig rate_config = loop_config;
+        rate_config.frame_rate_per_second = test_sensor.get_frame_rate_hz();
+        sleep_frame_rate(&frame_start_time, rate_config);
     }
 }

--- a/src/hololink/emulation/examples/emulator_utils.hpp
+++ b/src/hololink/emulation/examples/emulator_utils.hpp
@@ -30,6 +30,7 @@
 #include "dlpack/dlpack.h"
 #include "hololink/emulation/data_plane.hpp"
 #include "hololink/emulation/hsb_config.hpp"
+#include "hololink/emulation/sensors/test_sensor.hpp"
 #include "hololink/emulation/sensors/vb1940_emulator.hpp"
 
 #define MS_PER_SEC (1000.0)
@@ -69,5 +70,11 @@ void loop_single_vb1940(struct LoopConfig& loop_config, hololink::emulation::sen
 
 // the thread loop for serving two frames simultaneously (configured on host side) in vb1940 csi-2 format as if from stereo vb1940 sensors
 void loop_stereo_vb1940(struct LoopConfig& loop_config, hololink::emulation::sensors::Vb1940Emulator& vb1940_0, hololink::emulation::DataPlane& data_plane_0, DLTensor& tensor_0, hololink::emulation::sensors::Vb1940Emulator& vb1940_1, hololink::emulation::DataPlane& data_plane_1, DLTensor& tensor_1);
+
+// generate a test frame buffer from TestSensor configuration
+void generate_test_frame(DLTensor& frame_data, hololink::emulation::sensors::TestSensor& test_sensor, uint64_t frame_index);
+
+// loop serving raw test frames when the TestSensor is in streaming mode (frame rate from I2C)
+void loop_single_test(struct LoopConfig& loop_config, hololink::emulation::sensors::TestSensor& test_sensor, hololink::emulation::DataPlane& data_plane, DLTensor& frame_data);
 
 #endif // EXAMPLES_EMULATOR_UTILS_HPP

--- a/src/hololink/emulation/examples/serve_coe_test_data.cpp
+++ b/src/hololink/emulation/examples/serve_coe_test_data.cpp
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <getopt.h>
+#include <stdexcept>
+#include <stdio.h>
+#include <string.h>
+
+#include "dlpack/dlpack.h"
+#include "emulator_utils.hpp"
+#include "hololink/emulation/coe_data_plane.hpp"
+#include "hololink/emulation/hsb_config.hpp"
+#include "hololink/emulation/sensors/test_sensor.hpp"
+
+/**
+ * @brief Example program to serve test-pattern frames over CoE using TestSensor.
+ *
+ * The host configures the emulator over I2C (frame size, pattern, frame rate, streaming).
+ * When streaming is enabled, this program generates frames and sends them through COEDataPlane.
+ *
+ * Default values:
+ * - frame-limit: 0 (infinite)
+ * - gpu: false (serve data from CPU)
+ */
+
+using namespace hololink::emulation;
+
+#define DEFAULT_NUM_FRAMES 0
+
+void print_usage(char const* program_name)
+{
+    printf("Usage: %s [options] <hololink_ip_address>\n"
+           "    serves test-pattern frames over CoE from ip address 'hololink_ip_address'\n\n"
+           "    hololink_ip_address: IP address of the HSB Emulator device.\n"
+           "    -l, --frame-limit NUM_FRAMES: number of frames to serve (default: %d - infinite)\n"
+           "    -g, --gpu: serve the data from the GPU.\n"
+           "    -h, --help: print this message.\n"
+           "    Example: %s --frame-limit 100 192.168.0.12\n",
+        program_name, DEFAULT_NUM_FRAMES, program_name);
+}
+
+void parse_args(int argc, char** argv, struct LoopConfig& loop_config, bool& gpu)
+{
+    int c;
+    while (1) {
+        static struct option long_options[] = {
+            { "help", no_argument, NULL, 'h' },
+            { "frame-limit", required_argument, NULL, 'l' },
+            { "gpu", no_argument, NULL, 'g' },
+            { 0, 0, 0, 0 }
+        };
+        int option_index = 0;
+        c = getopt_long(argc, argv, "hgl:", long_options, &option_index);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            print_usage(argv[0]);
+            exit(EXIT_SUCCESS);
+        case 'g':
+            gpu = true;
+            break;
+        case 'l': {
+            long frame_limit = atol(optarg);
+            if (frame_limit < 0) {
+                throw std::invalid_argument("frame-limit must be a non-negative integer");
+            }
+            loop_config.num_frames = static_cast<unsigned int>(frame_limit);
+            break;
+        }
+        default:
+            fprintf(stderr, "Unknown option: %d\n", c);
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+int main(int argc, char** argv)
+{
+    char const* program_name = argv[0];
+    if (argc < 2) {
+        print_usage(program_name);
+        return -1;
+    }
+
+    struct LoopConfig loop_config = {
+        .num_frames = DEFAULT_NUM_FRAMES,
+        .frame_rate_per_second = 1, // overridden each iteration from TestSensor I2C config
+    };
+    bool gpu = false;
+    parse_args(argc, argv, loop_config, gpu);
+    if (optind >= argc) {
+        fprintf(stderr, "ip address not provided\n");
+        print_usage(program_name);
+        exit(EXIT_FAILURE);
+    }
+    std::string ip_address = argv[optind];
+
+    int64_t shape[1] = { 0 };
+    DLTensor tensor = {
+        .device = {
+            .device_type = gpu ? DLDeviceType::kDLCUDA : DLDeviceType::kDLCPU,
+            .device_id = 0 },
+        .ndim = 1,
+        .dtype = DLDataType { .code = DLDataTypeCode::kDLUInt, .bits = 8, .lanes = 1 },
+        .shape = &shape[0]
+    };
+
+    HSBEmulator hsb;
+    const uint8_t data_plane_id = 0;
+    const uint8_t sensor_id = 0;
+    COEDataPlane coe_data_plane(
+        hsb,
+        IPAddress_from_string(ip_address),
+        data_plane_id,
+        sensor_id);
+
+    sensors::TestSensor test_sensor;
+    test_sensor.attach_to_i2c(hsb.get_i2c(hololink::I2C_CTRL), hololink::CAM_I2C_BUS + sensor_id);
+
+    hsb.start();
+
+    printf("Running HSB Emulator with TestSensor... Press Ctrl+C to stop\n");
+    loop_single_test(loop_config, test_sensor, coe_data_plane, tensor);
+
+    hsb.stop();
+
+    return 0;
+}

--- a/src/hololink/emulation/python/hololink/emulation/sensors/__init__.py
+++ b/src/hololink/emulation/python/hololink/emulation/sensors/__init__.py
@@ -15,8 +15,16 @@
 #
 # See README.md for detailed information.
 
-from ._emulation_sensors import Vb1940Emulator
+from ._emulation_sensors import (
+    TEST_I2C_ADDRESS,
+    TestPatternMode,
+    TestSensor,
+    Vb1940Emulator,
+)
 
 __all__ = [
+    "TEST_I2C_ADDRESS",
+    "TestPatternMode",
+    "TestSensor",
     "Vb1940Emulator",
 ]

--- a/src/hololink/emulation/python/hololink/emulation/sensors/_sensors.cpp
+++ b/src/hololink/emulation/python/hololink/emulation/sensors/_sensors.cpp
@@ -18,6 +18,7 @@
 #include "hololink/emulation/data_plane.hpp"
 #include "hololink/emulation/hsb_emulator.hpp"
 #include "hololink/emulation/i2c_interface.hpp"
+#include "hololink/emulation/sensors/test_sensor.hpp"
 #include "hololink/emulation/sensors/vb1940_emulator.hpp"
 #include <pybind11/pybind11.h>
 
@@ -27,6 +28,23 @@ namespace hololink::emulation {
 
 PYBIND11_MODULE(_emulation_sensors, m)
 {
+
+    py::enum_<sensors::TestPatternMode>(m, "TestPatternMode")
+        .value("CONSTANT", sensors::TestPatternMode::CONSTANT)
+        .value("INCREMENTING", sensors::TestPatternMode::INCREMENTING);
+
+    py::class_<sensors::TestSensor, I2CPeripheral>(m, "TestSensor")
+        .def(py::init<>())
+        .def("reset", &sensors::TestSensor::reset, "reset the TestSensor")
+        .def("attach_to_i2c", &sensors::TestSensor::attach_to_i2c, "attach the TestSensor to an I2C controller")
+        .def("i2c_transaction", &sensors::TestSensor::i2c_transaction, "perform an I2C transaction")
+        .def("is_streaming", &sensors::TestSensor::is_streaming, "check if TestSensor is streaming")
+        .def("get_frame_size", &sensors::TestSensor::get_frame_size, "get the frame size in bytes")
+        .def("get_frame_rate_hz", &sensors::TestSensor::get_frame_rate_hz, "get the frame rate in Hz")
+        .def("get_pattern_mode", &sensors::TestSensor::get_pattern_mode, "get the pattern mode")
+        .def("get_constant_byte", &sensors::TestSensor::get_constant_byte, "get the constant pattern byte");
+
+    m.attr("TEST_I2C_ADDRESS") = sensors::TEST_I2C_ADDRESS;
 
     py::class_<sensors::Vb1940Emulator, I2CPeripheral>(m, "Vb1940Emulator")
         .def(py::init<>())

--- a/src/hololink/emulation/sensors/CMakeLists.txt
+++ b/src/hololink/emulation/sensors/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 add_library(emulation_sensors STATIC
+  test_sensor.cpp
   vb1940_emulator.cpp
 )
 target_compile_options(emulation_sensors PRIVATE -DHOLOSCAN_SDK_VERSION=${HOLOSCAN_SDK_VERSION} -g3)
@@ -39,7 +40,8 @@ install(TARGETS emulation_sensors
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT hololink-emulation-sensors)
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/vb1940_emulator.hpp
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/test_sensor.hpp
+              ${CMAKE_CURRENT_SOURCE_DIR}/vb1940_emulator.hpp
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hololink/emulation/sensors
         COMPONENT hololink-emulation-sensors)
 

--- a/src/hololink/emulation/sensors/test_sensor.cpp
+++ b/src/hololink/emulation/sensors/test_sensor.cpp
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_sensor.hpp"
+
+#include <cstring>
+
+namespace hololink::emulation::sensors {
+
+namespace {
+
+    constexpr uint32_t DEFAULT_FRAME_SIZE = 4096u;
+    constexpr uint32_t DEFAULT_FRAME_RATE_HZ = 30u;
+
+    bool is_write(uint16_t write_size)
+    {
+        return write_size > sizeof(uint16_t);
+    }
+
+    uint32_t read_u32_le(const uint8_t* memory, uint16_t reg_addr)
+    {
+        return static_cast<uint32_t>(memory[reg_addr]) | (static_cast<uint32_t>(memory[reg_addr + 1]) << 8)
+            | (static_cast<uint32_t>(memory[reg_addr + 2]) << 16) | (static_cast<uint32_t>(memory[reg_addr + 3]) << 24);
+    }
+
+    void write_u32_le(uint8_t* memory, uint16_t reg_addr, uint32_t value)
+    {
+        memory[reg_addr] = static_cast<uint8_t>(value);
+        memory[reg_addr + 1] = static_cast<uint8_t>(value >> 8);
+        memory[reg_addr + 2] = static_cast<uint8_t>(value >> 16);
+        memory[reg_addr + 3] = static_cast<uint8_t>(value >> 24);
+    }
+
+} // namespace
+
+TestSensor::TestSensor()
+    : I2CPeripheral()
+{
+    reset();
+}
+
+TestSensor::~TestSensor() { }
+
+void TestSensor::reset()
+{
+    memset(memory_, 0, sizeof(memory_));
+    memory_[DEVICE_ID_REG + 0] = 'H';
+    memory_[DEVICE_ID_REG + 1] = 'L';
+    memory_[DEVICE_ID_REG + 2] = 'T';
+    memory_[DEVICE_ID_REG + 3] = 'K';
+    write_u32_le(memory_, FRAME_SIZE_REG, DEFAULT_FRAME_SIZE);
+    memory_[PATTERN_MODE_REG] = static_cast<uint8_t>(TestPatternMode::INCREMENTING);
+    memory_[CONSTANT_BYTE_REG] = 0xA5;
+    write_u32_le(memory_, FRAME_RATE_REG, DEFAULT_FRAME_RATE_HZ);
+    memory_[STREAMING_REG] = 0;
+}
+
+void TestSensor::attach_to_i2c(I2CController& i2c_controller, uint8_t bus_address)
+{
+    i2c_controller.attach_i2c_peripheral(bus_address, TEST_I2C_ADDRESS, this);
+}
+
+I2CStatus TestSensor::i2c_transaction(uint16_t peripheral_address, const uint8_t* write_bytes, uint16_t write_size, uint8_t* read_bytes, uint16_t read_size)
+{
+    if (write_size < 2) {
+        return I2CStatus::I2C_STATUS_INVALID_REGISTER_ADDRESS;
+    }
+
+    if (peripheral_address != TEST_I2C_ADDRESS) {
+        return I2CStatus::I2C_STATUS_INVALID_PERIPHERAL_ADDRESS;
+    }
+
+    uint16_t reg_addr = write_bytes[1] | (write_bytes[0] << 8);
+
+    if (reg_addr == STREAMING_REG) {
+        return streaming_reg(write_bytes, write_size, read_bytes, read_size);
+    }
+
+    if (is_write(write_size)) {
+        uint16_t data_size = write_size - 2;
+        if (reg_addr + data_size > TEST_SENSOR_MEMORY_SIZE) {
+            return I2CStatus::I2C_STATUS_WRITE_FAILED;
+        }
+        if (reg_addr == FRAME_SIZE_REG) {
+            if (data_size != sizeof(uint32_t)) {
+                return I2CStatus::I2C_STATUS_WRITE_FAILED;
+            }
+            const uint32_t frame_size = static_cast<uint32_t>(write_bytes[2])
+                | (static_cast<uint32_t>(write_bytes[3]) << 8)
+                | (static_cast<uint32_t>(write_bytes[4]) << 16)
+                | (static_cast<uint32_t>(write_bytes[5]) << 24);
+            if (frame_size == 0) {
+                return I2CStatus::I2C_STATUS_WRITE_FAILED;
+            }
+        }
+        memcpy(&memory_[reg_addr], write_bytes + 2, data_size);
+    } else {
+        if (reg_addr + read_size > TEST_SENSOR_MEMORY_SIZE) {
+            return I2CStatus::I2C_STATUS_READ_FAILED;
+        }
+        memcpy(read_bytes, &memory_[reg_addr], read_size);
+    }
+    return I2CStatus::I2C_STATUS_SUCCESS;
+}
+
+I2CStatus TestSensor::streaming_reg(const uint8_t* write_bytes, uint16_t write_size, uint8_t* read_bytes, uint16_t read_size)
+{
+    if (is_write(write_size)) {
+        memory_[STREAMING_REG] = write_bytes[2] ? 1 : 0;
+        memory_[STATUS_REG] = memory_[STREAMING_REG];
+    } else if (read_size > 0) {
+        if (read_size > TEST_SENSOR_MEMORY_SIZE - STREAMING_REG) {
+            return I2CStatus::I2C_STATUS_READ_FAILED;
+        }
+        memcpy(read_bytes, &memory_[STREAMING_REG], read_size);
+    }
+    return I2CStatus::I2C_STATUS_SUCCESS;
+}
+
+bool TestSensor::is_streaming() const
+{
+    return memory_[STREAMING_REG] != 0;
+}
+
+uint32_t TestSensor::get_frame_size() const
+{
+    return read_u32_le(memory_, FRAME_SIZE_REG);
+}
+
+uint32_t TestSensor::get_frame_rate_hz() const
+{
+    uint32_t hz = read_u32_le(memory_, FRAME_RATE_REG);
+    return hz > 0 ? hz : DEFAULT_FRAME_RATE_HZ;
+}
+
+TestPatternMode TestSensor::get_pattern_mode() const
+{
+    return memory_[PATTERN_MODE_REG] == static_cast<uint8_t>(TestPatternMode::CONSTANT) ? TestPatternMode::CONSTANT : TestPatternMode::INCREMENTING;
+}
+
+uint8_t TestSensor::get_constant_byte() const
+{
+    return memory_[CONSTANT_BYTE_REG];
+}
+
+void TestSensor::fill_frame(uint8_t* data, uint64_t frame_index) const
+{
+    const uint32_t size = get_frame_size();
+    if (get_pattern_mode() == TestPatternMode::CONSTANT) {
+        memset(data, get_constant_byte(), size);
+        return;
+    }
+    for (uint32_t i = 0; i < size; ++i) {
+        data[i] = static_cast<uint8_t>((frame_index + i) & 0xFF);
+    }
+}
+
+} // namespace hololink::emulation::sensors

--- a/src/hololink/emulation/sensors/test_sensor.hpp
+++ b/src/hololink/emulation/sensors/test_sensor.hpp
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HOLOLINK_EMULATION_TEST_SENSOR_HPP
+#define HOLOLINK_EMULATION_TEST_SENSOR_HPP
+
+#include <cstdint>
+
+#include "../i2c_interface.hpp"
+
+#define TEST_SENSOR_MEMORY_SIZE 256u
+
+namespace hololink::emulation::sensors {
+
+/** I2C peripheral address for the test sensor. */
+constexpr uint8_t TEST_I2C_ADDRESS = 0x5A;
+
+/**
+ * @brief Pattern mode for generated frame payload.
+ */
+enum class TestPatternMode : uint8_t {
+    CONSTANT = 0,
+    INCREMENTING = 1,
+};
+
+/**
+ * @brief I2C-controlled test sensor for validation and development.
+ *
+ * Register map (16-bit big-endian address, same transaction format as Vb1940Emulator):
+ *
+ * | Address | Access | Description |
+ * |---------|--------|-------------|
+ * | 0x0000  | R      | Device ID bytes: 'H','L','T','K' |
+ * | 0x0010  | R/W    | Frame data size in bytes (32-bit, little-endian) |
+ * | 0x0014  | R/W    | Pattern mode: 0=constant, 1=incrementing |
+ * | 0x0015  | R/W    | Constant pattern byte (used when pattern mode is constant) |
+ * | 0x0020  | R/W    | Frame rate in Hz (32-bit, little-endian) |
+ * | 0x0030  | R/W    | Streaming control: write 1=start, 0=stop; read returns state |
+ * | 0x0031  | R      | Status: bit0 = streaming active |
+ */
+class TestSensor : public I2CPeripheral {
+public:
+    TestSensor();
+    ~TestSensor();
+
+    void reset();
+
+    void attach_to_i2c(I2CController& i2c_controller, uint8_t bus_address) override;
+
+    I2CStatus i2c_transaction(uint16_t peripheral_address, const uint8_t* write_bytes, uint16_t write_size, uint8_t* read_bytes, uint16_t read_size) override;
+
+    bool is_streaming() const;
+    uint32_t get_frame_size() const;
+    uint32_t get_frame_rate_hz() const;
+    TestPatternMode get_pattern_mode() const;
+    uint8_t get_constant_byte() const;
+
+    /**
+     * @brief Fill a frame buffer according to the current pattern configuration.
+     * @param data Destination buffer (must be at least get_frame_size() bytes).
+     * @param frame_index Frame sequence number used by the incrementing pattern.
+     */
+    void fill_frame(uint8_t* data, uint64_t frame_index) const;
+
+private:
+    static constexpr uint16_t DEVICE_ID_REG = 0x0000u;
+    static constexpr uint16_t FRAME_SIZE_REG = 0x0010u;
+    static constexpr uint16_t PATTERN_MODE_REG = 0x0014u;
+    static constexpr uint16_t CONSTANT_BYTE_REG = 0x0015u;
+    static constexpr uint16_t FRAME_RATE_REG = 0x0020u;
+    static constexpr uint16_t STREAMING_REG = 0x0030u;
+    static constexpr uint16_t STATUS_REG = 0x0031u;
+
+    I2CStatus streaming_reg(const uint8_t* write_bytes, uint16_t write_size, uint8_t* read_bytes, uint16_t read_size);
+
+    uint8_t memory_[TEST_SENSOR_MEMORY_SIZE] = { 0 };
+};
+
+} // namespace hololink::emulation::sensors
+
+#endif // HOLOLINK_EMULATION_TEST_SENSOR_HPP


### PR DESCRIPTION
Add an example program to configure `FusaCoeCaptureOp` to receive non-CSI data formats/generic frames.

Add a `TestSensor` I2CPeripheral for the HSB Emulator to transmit non-CSI simulated data patterns to the `FusaCoeCaptureOp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a test sensor emulator with configurable frame patterns, sizes, and rates for development and testing scenarios.
  * Introduced example applications demonstrating test sensor integration with CoE interfaces.
  * Exposed test sensor functionality through Python bindings for programmatic control.

* **Build System**
  * Updated build configuration to include new example executable targets and sensor headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->