### PR TITLE
Fix CDC issue: Synchronize i_hsb_stat[0] in bootp module

### DIFF
--- a/fpga/nv_hsb_ip/bootp/bootp.sv
+++ b/fpga/nv_hsb_ip/bootp/bootp.sv
@@ -363,8 +363,24 @@ logic [23:0] pkt_cnt_be;
 assign pkt_cnt_be = {pkt_cnt[out_host_idx][7:0],pkt_cnt[out_host_idx][15:8],pkt_cnt[out_host_idx][23:16]};
 
 logic [BOOTP_VEND_DATA_WIDTH-1:0] bootp_vend_data;
+logic  [7:0]             i_hsb_stat_sync;
+
+// i_hsb_stat[0] is generated in ptp_top.sv @ i_ptp_clk, 
+// therefore, in bootp block it need to be sync on i_hif_clk 
+data_sync #(
+  .DATA_WIDTH    (8),
+  .RESET_VALUE   (0),
+  .SYNC_DEPTH    (2),
+  .RST_SYNC      ("TRUE")
+) i_hsb_stat_sync_inst (
+  .clk (i_clk),
+  .rst_n (~i_rst),
+  .sync_in (i_hsb_stat),
+  .sync_out (i_hsb_stat_sync)
+);
+  
 assign bootp_vend_data = {
-  i_hsb_stat, psn_be, ptp_be, i_enum_data[ENUM_DWIDTH-1:176],8'h0,pkt_cnt_be, uuid_be, 16'd0, bootp_vend_prefix
+  i_hsb_stat_sync, psn_be, ptp_be, i_enum_data[ENUM_DWIDTH-1:176],8'h0,pkt_cnt_be, uuid_be, 16'd0, bootp_vend_prefix
 };
 
 vec_to_axis #(


### PR DESCRIPTION
Hi,

I noticed a Clock Domain Crossing (CDC) issue where the signal `i_hsb_stat` in the `bootp.sv` module is being used without proper synchronization.

Details:

Currently, only bit-0 (i_hsb_stat[0]) is connected in bootp.sv (Line 330).
  https://github.com/nvidia-holoscan/holoscan-sensor-bridge/blob/fc2a6cfd7e85cd04d771fbf03ac45e3e7c57b5e1/fpga/nv_hsb_ip/top/HOLOLINK_top.sv#L330


This net is driven by the output signal o_ptp_en_sync_rx from the ptp_top block, as seen in ptp_top.sv (Line 58).
  https://github.com/nvidia-holoscan/holoscan-sensor-bridge/blob/fc2a6cfd7e85cd04d771fbf03ac45e3e7c57b5e1/fpga/nv_hsb_ip/ptp/ptp_top.sv#L58

Problem:
The i_hsb_stat[0] signal is generated in the ptp_top domain clocked by i_ptp_clk. However, the bootp block operates on i_hif_clk. Using this signal directly without synchronization can lead to metastability.

Solution:
This PR adds the necessary synchronization logic to safely cross i_hsb_stat[0] over to the i_hif_clk domain before it is consumed by the bootp block.

Regards,
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BOOTP vendor data reliability by sourcing it from a clock-domain synchronized status signal, reducing the chance of inconsistent or unstable values when operating across clock domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->