### PR TITLE
fix user guide broken links due to change in user guide url

### DIFF
--- a/MPF200-ETH-SENSOR-BRIDGE_README.txt
+++ b/MPF200-ETH-SENSOR-BRIDGE_README.txt
@@ -58,7 +58,7 @@ Running imx477 application - Tao People net
 	a. xhost +
 	b. sh docker/demo.sh <enter>
 		b.1: It runs holoscan-sensor-bridge docker container
-	c. https://docs.nvidia.com/holoscan/sensor-bridge/latest/examples.html#running-the-tao-peoplenet-example
+	c. https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/examples#running-the-tao-peoplenet-example
 3. Connect Ethernet cable from AGX to J6 connector on MPF200-ETH-SENSOR-BRIDGE. Connect the camera to J14 MIPI connector.  Run the below commands to run linux_tao_peoplenet_imx477 for camera 0 
 	a. python examples/linux_tao_peoplenet_imx477.py
 		1.1 The above command runs tao peoplenet model on video from camera 0
@@ -74,7 +74,7 @@ Running imx477 application - body pose estimation
 	a. xhost +
 	b. sh docker/demo.sh <enter>
 		b.1: It runs holoscan-sensor-bridge docker container
-	c. https://docs.nvidia.com/holoscan/sensor-bridge/latest/examples.html#running-the-body-pose-example
+	c. https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/examples#running-the-body-pose-example
 3. Connect Ethernet cable from AGX to J6 connector on MPF200-ETH-SENSOR-BRIDGE. Connect the camera to J14 MIPI connector.  Run the below commands to run linux_body_pose_estimation_imx477 for camera 0 
 	a. python examples/linux_body_pose_estimation_imx477.py
 		1.1 The above command runs body pose estimation model on video from camera 0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or an IMX477 camera with
 ## Setup
 
 Holoscan sensor bridge software comes with an
-[extensive user guide](https://docs.nvidia.com/holoscan/sensor-bridge/latest/),
+[extensive user guide](https://docs.nvidia.com/holoscan/sensor-bridge/index.html),
 including instructions for setup on
 [NVIDIA IGX](https://www.nvidia.com/en-us/edge-computing/products/igx/) and
 [NVIDIA AGX](https://developer.nvidia.com/embedded/learn/jetson-agx-orin-devkit-user-guide/index.html)
@@ -31,7 +31,7 @@ link:
 ## Troubleshooting
 
 Be sure and check the
-[release notes](https://docs.nvidia.com/holoscan/sensor-bridge/latest/release_notes.html)
+[release notes](https://docs.nvidia.com/holoscan/sensor-bridge/support/release-notes)
 for frequently asked questions and troubleshooting tips.
 
 ## Submitting changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,14 +66,14 @@ host system, run `sh docs/make_docs.sh`, then use your browser to look at
 - **LeopardImaging Eagle Camera** Support for 8-bit, 60 fps mode on AGX Thor
 - **Lattice IMX274** Support for 12-bit, 30 fps mode
 - **Firmware Setup** `hsb_flasher` as primary
-  [firmware setup](https://docs.nvidia.com/holoscan/sensor-bridge/latest/sensor_bridge_firmware_setup.html)
+  [firmware setup](https://docs.nvidia.com/holoscan/sensor-bridge/firmware/firmware-setup#hsb-flasher)
   tool.
 - **CoE Offload Features** SIPLCaptureService for HSBs running sensors at heterogeneous
   frame rates. More generic sensor frame/non-image layout support in FusaCoeCapture
   operator
 - **SubFrameVisualizerOp** to improve support for sub-frame processing
 - **x86 Linux** added
-  [RoCE setup support](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.html#sd-tab-item-4)
+  [RoCE setup support](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup#igx)
 - **Agentic AI** Added
   [skills](https://github.com/nvidia-holoscan/holoscan-sensor-bridge/tree/main/skills)
   directory for workflows or setup involving HSB
@@ -189,7 +189,7 @@ host system, run `sh docs/make_docs.sh`, then use your browser to look at
 - **Thor support with Leopard Eagle VB1940 cameras.** Documentation and device
   programming support is included to support JP7.0 based Thor configurations with the
   Leopard Eagle VB1940 camera. See
-  [Thor JP7 setup instructions here](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.md).
+  [Thor JP7 setup instructions here](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup).
 
 ## 2.2-GA, August 2025
 
@@ -270,7 +270,7 @@ host system, run `sh docs/make_docs.sh`, then use your browser to look at
 
 - PTP configuration following boot-up is very touchy and error-prone. If you have
   trouble with received PTP timestamps, make sure you follow the user guide
-  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.html)
+  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup)
   carefully.
 
 - Running tools like "nomachine" on non-RDMA capable systems--where CPU is used to
@@ -280,7 +280,7 @@ host system, run `sh docs/make_docs.sh`, then use your browser to look at
   is delivered to the holoscan pipeline, we clear the receiver buffer to all 0xFF. If a
   UDP packet with video data is dropped, then that 0xFF wouldn't be replaced with actual
   video data-- and that's where the white streaks come from. Adjusting `rmem_max` (per
-  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.html))
+  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup))
   and adjusting core affinity for your application may help mitigate packet loss.
 
 ### Known Anomalies
@@ -331,7 +331,7 @@ look at `docs/user_guide/_build/html/index.html`.
   host systems, which support hardware PTP synchronization, these timestamps are within
   a microsecond of the host time, and can be used to accurately measure latency through
   the pipeline. These metadata values are available to pipeline operators via the
-  [HSDK application metadata API](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata).
+  [HSDK application metadata API](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#working-with-metadata-from-operatorcompute).
   See the user guide for more details. Sequence number checking is enabled for control
   plane transactions, and can provide protection against interaction from several hosts
   to the same HSB unit. The overall CRC of the received data frame is also included, in
@@ -380,7 +380,7 @@ look at `docs/user_guide/_build/html/index.html`.
   the 2412 configuration; the newer tree must be used to write the older firmware.
 
 - HSB network receiver operators use
-  [APIs provided by the Holoscan SDK](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata)
+  [APIs provided by the Holoscan SDK](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#working-with-metadata-from-operatorcompute)
   to share timestamps with later operators in the pipeline. Be sure and call the
   application (C++) `is_metadata_enabled(true)` method or (python)
   `is_metadata_enabled = True` at initialization time; otherwise each operator will only

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -388,7 +388,7 @@ look at `docs/user_guide/_build/html/index.html`.
   additional items to the pipeline metadata, be sure and add that metadata before
   calling `(output).emit`. If you have a pipeline that merges two paths, and experience
   a `runtime_error` exception when it fails to merge the metadata from those paths, see
-  [the page on Metadata update policies](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#metadata-update-policies)
+  [the page on Metadata update policies](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#metadata-update-policies)
   for information on how to manage this.
 
 - It is possible to overrun the bandwidth available on the ethernet, particularly when

--- a/docs/user_guide/applications.mdx
+++ b/docs/user_guide/applications.mdx
@@ -1,4 +1,4 @@
-[Holoscan](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_core.html)
+[Holoscan](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/holoscan-core)
 applications are built by specifying sequences of operators. Connecting the output of
 one operator to the input of another operator (via the `add_flow` API) configures
 Holoscan's pipeline and specifies when individual operators can run.
@@ -391,7 +391,7 @@ but the socket on the parent interface does not see them.
 
 A demonstration application where inference is used to generate a video overlay is
 included in examples/tao_peoplenet.py. The
-[Tao PeopleNet](https://docs.nvidia.com/tao/tao-toolkit/text/model_zoo/cv_models/peoplenet.html)
+[Tao PeopleNet](https://docs.nvidia.com/tao/archive/5.3.0/text/model_zoo/cv_models/peoplenet.html)
 is used to determine the locations of persons, bags, and faces in the live video stream.
 This example program draws bounding boxes on an overlay illustrating where those objects
 are detected in the video frame.

--- a/docs/user_guide/architecture.mdx
+++ b/docs/user_guide/architecture.mdx
@@ -303,7 +303,7 @@ are sent by the host to UDP port 12268.
 ConnectX SmartNIC firmware has support for handling authenticated
 [RoCE v2](https://en.wikipedia.org/wiki/RDMA_over_Converged_Ethernet) requests without
 CPU intervention. Sensor bridge devices leverage this by generating
-[RDMA write and RDMA write with immediate requests](https://docs.nvidia.com/networking/display/rdmaawareprogrammingv17/available+communication+operations)
+[RDMA write and RDMA write with immediate requests](https://networking-docs.nvidia.com/doca/archive/3-4-0/rdma-aware-networks-programming-guide#RDMA-Write/RDMA-Write-With-Immediate)
 to send data plane content to the host. DataChannel configures the sensor bridge device
 with target network addressing, authentication keys, and individual-packet and overall
 data-frame sizes. Once configured, the sensor bridge device will send received sensor

--- a/docs/user_guide/examples.mdx
+++ b/docs/user_guide/examples.mdx
@@ -287,7 +287,7 @@ For AGX Thor T5000 with FuSa CoE accelerated receiver:
 ## Running the TAO PeopleNet example
 
 The tao-peoplenet example demonstrates running inference on a live video feed.
-[Tao PeopleNet](https://docs.nvidia.com/tao/tao-toolkit/text/model_zoo/cv_models/peoplenet.html)
+[Tao PeopleNet](https://docs.nvidia.com/tao/archive/5.3.0/text/model_zoo/cv_models/peoplenet.html)
 provides a model that given an image can detect persons, bags, and faces. In this
 example, when those items are detected, bounding boxes are shown as an overlay over the
 live video.

--- a/docs/user_guide/introduction.mdx
+++ b/docs/user_guide/introduction.mdx
@@ -28,7 +28,7 @@ systems. Additionally:
 
 ## Software
 
-[Holoscan](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_core.html)
+[Holoscan](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/holoscan-core)
 applications are written by composing lists of operators. Connecting the output of one
 operator to the input of another operator (via the `add_flow` API) configures Holoscan's
 pipeline and specifies when individual operators can run.
@@ -81,9 +81,9 @@ do not include application-specific behavior.
 ## Host requirements
 
 Holoscan Sensor Bridge software can be run on any system that is supported by NVIDIA
-[Holoscan](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_core.html). For the
-best performance, an [IGX](https://www.nvidia.com/en-us/edge-computing/products/igx)
-system using
+[Holoscan](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/holoscan-core).
+For the best performance, an
+[IGX](https://www.nvidia.com/en-us/edge-computing/products/igx) system using
 [ConnectX SmartNICs](https://www.nvidia.com/content/dam/en-zz/Solutions/networking/ethernet-adapters/connectx-7-datasheet-Final.pdf)
 is recommended. In systems without ConnectX NICs, such as the
 [Jetson AGX Orin](https://developer.nvidia.com/embedded/learn/jetson-agx-orin-devkit-user-guide/index.html),

--- a/docs/user_guide/latency.mdx
+++ b/docs/user_guide/latency.mdx
@@ -11,7 +11,7 @@ includes:
 
 When host PTP support is properly configured, this time is synchronized with the host
 time to within one microsecond. HSDK operators can access this metadata using
-[APIs provided by the Holoscan SDK](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata).
+[APIs provided by the Holoscan SDK](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#working-with-metadata-from-operatorcompute).
 Notes:
 
 - Timestamps are comparable to the clock values read from the

--- a/docs/user_guide/release_notes.mdx
+++ b/docs/user_guide/release_notes.mdx
@@ -1,3 +1,21 @@
+## 2.7-GA, July 2026
+
+### Dependencies
+
+- IGX Orin:
+  [IGX-SW 1.1.3 Production Release](https://developer.nvidia.com/igx-downloads)
+- IGX Thor: [IGX-SW 2.0 Production Release](https://developer.nvidia.com/igx-downloads)
+- AGX Orin: Use [SDK Manager](https://developer.nvidia.com/sdk-manager) to set up
+  JetPack 7.2.
+- AGX Thor: Use [SDK Manager](https://developer.nvidia.com/sdk-manager) to set up
+  JetPack 7.2.
+- Holoscan Sensor Bridge, 10G; FPGA v2606.
+
+Be sure and follow the installation instructions included with the release, including
+PTP configuration and HSB device firmware updates. To generate documentation, in the
+host system, run `sh docs/make_docs.sh --preview`, then use your browser to look at
+`http://localhost:3000`.
+
 ## 2.6-GA, June 2026
 
 ### Dependencies
@@ -25,14 +43,14 @@ PTP configuration and HSB device firmware updates. To preview documentation loca
 - **LeopardImaging Eagle Camera** Support for 8-bit, 60 fps mode on AGX Thor
 - **Lattice IMX274** Support for 12-bit, 30 fps mode
 - **Firmware Setup** `hsb_flasher` as primary
-  [firmware setup](https://docs.nvidia.com/holoscan/sensor-bridge/latest/sensor_bridge_firmware_setup.html)
+  [firmware setup](https://docs.nvidia.com/holoscan/sensor-bridge/firmware/firmware-setup#hsb-flasher)
   tool.
 - **CoE Offload Features** SIPLCaptureService for HSBs running sensors at heterogeneous
   frame rates. More generic sensor frame/non-image layout support in FusaCoeCapture
   operator
 - **SubFrameVisualizerOp** to improve support for sub-frame processing
 - **x86 Linux** added
-  [RoCE setup support](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.html#sd-tab-item-4)
+  [RoCE setup support](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup#igx)
 - **Agentic AI** Added
   [skills](https://github.com/nvidia-holoscan/holoscan-sensor-bridge/tree/main/skills)
   directory for workflows or setup involving HSB
@@ -148,7 +166,7 @@ PTP configuration and HSB device firmware updates. To preview documentation loca
 - **Thor support with Leopard Eagle VB1940 cameras.** Documentation and device
   programming support is included to support JP7.0 based Thor configurations with the
   Leopard Eagle VB1940 camera. See
-  [Thor JP7 setup instructions here](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup).
+  [Thor JP7 setup instructions here](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup).
 
 ## 2.2-GA, August 2025
 
@@ -229,7 +247,7 @@ PTP configuration and HSB device firmware updates. To preview documentation loca
 
 - PTP configuration following boot-up is very touchy and error-prone. If you have
   trouble with received PTP timestamps, make sure you follow the user guide
-  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.html)
+  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup)
   carefully.
 
 - Running tools like "nomachine" on non-RDMA-capable systems--where CPU is used to
@@ -239,7 +257,7 @@ PTP configuration and HSB device firmware updates. To preview documentation loca
   is delivered to the holoscan pipeline, we clear the receiver buffer to all 0xFF. If a
   UDP packet with video data is dropped, then that 0xFF wouldn't be replaced with actual
   video data-- and that's where the white streaks come from. Adjusting `rmem_max` (per
-  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/latest/setup.html))
+  [host setup instructions](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/host-setup))
   and adjusting core affinity for your application may help mitigate packet loss.
 
 ### Known Anomalies
@@ -290,7 +308,7 @@ repository root, then `cd docs/user_guide/fern && fern docs dev`.
   host systems, which support hardware PTP synchronization, these timestamps are within
   a microsecond of the host time, and can be used to accurately measure latency through
   the pipeline. These metadata values are available to pipeline operators via the
-  [HSDK application metadata API](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata).
+  [HSDK application metadata API](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#working-with-metadata-from-operatorcompute).
   See the user guide for more details. Sequence number checking is enabled for control
   plane transactions, and can provide protection against interaction from several hosts
   to the same HSB unit. The overall CRC of the received data frame is also included, in
@@ -339,7 +357,7 @@ repository root, then `cd docs/user_guide/fern && fern docs dev`.
   the 2412 configuration; the newer tree must be used to write the older firmware.
 
 - HSB network receiver operators use
-  [APIs provided by the Holoscan SDK](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata)
+  [APIs provided by the Holoscan SDK](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#working-with-metadata-from-operatorcompute)
   to share timestamps with later operators in the pipeline. Be sure and call the
   application (C++) `is_metadata_enabled(true)` method or (python)
   `is_metadata_enabled = True` at initialization time; otherwise each operator will only
@@ -347,7 +365,7 @@ repository root, then `cd docs/user_guide/fern && fern docs dev`.
   additional items to the pipeline metadata, be sure and add that metadata before
   calling `(output).emit`. If you have a pipeline that merges two paths, and experience
   a `runtime_error` exception when it fails to merge the metadata from those paths, see
-  [the page on Metadata update policies](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#metadata-update-policies)
+  [the page on Metadata update policies](https://docs.nvidia.com/holoscan/sdk-user-guide/4-4-latest/using-the-sdk/create-an-application#metadata-update-policies)
   for information on how to manage this.
 
 - It is possible to overrun the bandwidth available on the ethernet, particularly when

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
       "cpp": "hololink",
       "python": "hololink"
     },
-    "homepage": "https://docs.nvidia.com/holoscan/sensor-bridge/latest/",
+    "homepage": "https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/introduction",
     "platforms": ["x86_64", "aarch64"],
     "tags": [
       "sensor-bridge",

--- a/python/hololink/operators/pva_crc/README.md
+++ b/python/hololink/operators/pva_crc/README.md
@@ -14,7 +14,7 @@ Hardware-accelerated CRC validation using NVIDIA PVA (Programmable Vision Accele
   - These versions come with PVA runtime v2.9 installed at `/opt/nvidia/pva-sdk-2.9`
 - Hololink demo container
   - Refer to
-    [Build and Test Holoscan Sensor Bridge demo container](https://docs.nvidia.com/holoscan/sensor-bridge/latest/build.html)
+    [Build and Test Holoscan Sensor Bridge demo container](https://docs.nvidia.com/holoscan/sensor-bridge/getting-started/build)
 
 ## PVA CRC Files
 

--- a/scripts/nsexec.sh
+++ b/scripts/nsexec.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # This is a convenience script used by tests/test_emulator.py to execute a command in the network namespace ns_<if_name>
-# For use cases, see https://docs.nvidia/com/holoscan/sensor-bridge/latest/emulation.html#testing
+# For use cases, see https://docs.nvidia.com/holoscan/sensor-bridge/emulation/hsb-emulator#testing
 
 if [ $# -lt 2 ] ; then
 	echo "Usage: $0 <if_name> <command> [args...]"

--- a/scripts/nsjoin.sh
+++ b/scripts/nsjoin.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # This is a convenience script used by pytest hw_loopback session fixture in tests/conftest.py to remove the interface from the network namespace and add an IPV4 address to it
-# For use cases, see https://docs.nvidia/com/holoscan/sensor-bridge/latest/emulation.html#testing
+# For use cases, see https://docs.nvidia.com/holoscan/sensor-bridge/emulation/hsb-emulator#testing
 
 if [ $# -lt 1 ] ; then
 	echo "Usage: $0 <if_name> [<ipv4>]"


### PR DESCRIPTION
The user guide has moved to a new URL, so this update fixes links to that new location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated links throughout the user guides, READMEs, and release notes to point to current non-`latest/` NVIDIA documentation targets.
  - Refreshed setup, troubleshooting, firmware, RoCE, Thor JP7 setup, emulator testing, metadata, architecture, and example reference links.
  - Updated the PeopleNet model and related references to the archived TAO 5.3.0 documentation.
  - Added a new **2.7-GA (July 2026)** entry, including updated dependency documentation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->