### PR TITLE
Update version number in user guide to 2.7 (Latest)

### DIFF
--- a/docs/user_guide/fern/docs.yml
+++ b/docs/user_guide/fern/docs.yml
@@ -18,7 +18,7 @@ products:
     slug: /
     path: index.yml
     versions:
-      - display-name: 2.6 (Latest)
+      - display-name: 2.7 (Latest)
         path: ./index.yml
         availability: ga
       - display-name: Archives


### PR DESCRIPTION
The fern documentation yaml script still had 2.6 as the release version in it; this update fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the user guide to identify version 2.7 as the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->