### PR TITLE
Fixing redirects for documentation

### DIFF
--- a/docs/user_guide/fern/docs.yml
+++ b/docs/user_guide/fern/docs.yml
@@ -74,6 +74,10 @@ css:
   - dist/output.css
 
 redirects:
+  - source: "/holoscan/sensor-bridge/latest/index.html"
+    destination: "/holoscan/sensor-bridge"
+  - source: "/holoscan/sensor-bridge/latest"
+    destination: "/holoscan/sensor-bridge"
   - source: "/holoscan/sensor-bridge/index.html"
     destination: "/holoscan/sensor-bridge/getting-started/introduction"
   - source: "/holoscan/sensor-bridge/introduction"


### PR DESCRIPTION
Ensure that `https://docs.nvidia.com/holoscan/sensor-bridge/latest` is properly handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added redirects for legacy Holoscan Sensor Bridge documentation URLs.
  * Both versioned paths now lead directly to the current Sensor Bridge documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->