### PR TITLE
re-add emulator API documentation and fix fern migration bash issues

### DIFF
--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -18,7 +18,7 @@
 # See docs/user_guide/README.md for detailed information.
 #
 # Usage:
-#   docs/make_docs.sh [--preview|--dev] [--no-docker] ...
+#   docs/make_docs.sh [--preview|--dev] [--no-docker] [--with-library-mdx] ...
 #   DOCKER_OPTS='-e MY_VAR=1' docs/make_docs.sh   # extra docker run flags
 #
 # DOCKER_OPTS: optional extra flags passed to `docker run` (unset = none).
@@ -36,6 +36,8 @@ Options:
   --login                Log in to Fern (device-code in Docker; browser on host)
   --no-docker            Run on the host instead of the docs container
   --docker               Use the docs container (default)
+  --with-library-mdx     Generate the Emulation C++ API MDX (requires Fern auth)
+  --skip-library-mdx     Skip C++ API generation
   --skip-fern-check      Pipeline only; skip fern check
   --publish              Publish docs to production (docs.nvidia.com)
   --publish-preview      Publish a remote Fern docs preview (CI)
@@ -49,7 +51,7 @@ Options:
 Environment:
   DOCKER_OPTS            Extra flags for docker run (optional; default: empty).
   FERN_TOKEN             Non-expiring Fern org API token from 'fern token', for
-                         publishing (optional). The 'fern login' credential in
+                         C++ API generation and publishing (optional). The 'fern login' credential in
                          ~/.fern is shared into the container automatically and
                          is NOT used as FERN_TOKEN.
 EOF
@@ -74,6 +76,12 @@ while [ $# -ge 1 ]; do
             ARGS="$ARGS --no-docker"
             ;;
         --docker)
+            ;;
+        --with-library-mdx)
+            ARGS="$ARGS --with-library-mdx"
+            ;;
+        --skip-library-mdx)
+            ARGS="$ARGS --skip-library-mdx"
             ;;
         --skip-fern-check)
             ARGS="$ARGS --skip-fern-check"

--- a/docs/scripts/build_hololink_docs.py
+++ b/docs/scripts/build_hololink_docs.py
@@ -18,9 +18,12 @@ Build and validate Holoscan Sensor Bridge Fern documentation.
 
 User guide pages are committed as ``*.mdx`` under ``docs/user_guide/``. Fern config
 (``fern.config.json``, ``docs.yml``, ``index.yml``, ``assets/``, ``dist/``) lives under
-``docs/user_guide/fern/``.
+``docs/user_guide/fern/``. The public C++ API for ``src/hololink/emulation`` is
+generated under ``docs/user_guide/fern/generated/``.
 
-``fern check --local`` (local validation), ``fern docs dev`` (``--preview``),
+With ``--with-library-mdx``, the pipeline runs ``fern docs md generate`` and
+post-processes the generated MDX before ``fern check --local`` (local validation),
+``fern docs dev`` (``--preview``),
 ``fern generate --docs --preview`` (``--publish-preview`` for CI), or
 ``fern generate --docs`` (``--publish`` for production).
 
@@ -29,6 +32,7 @@ Usage (from hololink repo root):
   python3 docs/scripts/build_hololink_docs.py
   python3 docs/scripts/build_hololink_docs.py --preview
   python3 docs/scripts/build_hololink_docs.py --no-docker
+  python3 docs/scripts/build_hololink_docs.py --with-library-mdx
   python3 docs/scripts/build_hololink_docs.py --skip-fern-check
   python3 docs/scripts/build_hololink_docs.py --publish
   python3 docs/scripts/build_hololink_docs.py --publish-preview --preview-id my-branch --force
@@ -53,6 +57,7 @@ DOCS_ROOT = DOCS_DIR / "user_guide"
 REPO = DOCS_DIR.parent
 SOURCE = DOCS_ROOT
 DEFAULT_FERN_DIR = DOCS_ROOT / "fern"
+FIX_LIBRARY_MDX = SCRIPTS / "fix_generated_library_mdx.py"
 DOCKERFILE = DOCS_DIR / "Dockerfile.docs"
 
 ASSET_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
@@ -404,6 +409,71 @@ def _fern_auth_token() -> str | None:
     return None
 
 
+def _has_fern_org_token() -> bool:
+    """Return whether an explicit org token is available for library generation."""
+    return _env_fern_token() is not None
+
+
+def _clean_generated_api_docs(generated_docs: Path) -> None:
+    if generated_docs.is_dir():
+        shutil.rmtree(generated_docs)
+        try:
+            removed = generated_docs.relative_to(REPO)
+        except ValueError:
+            removed = generated_docs
+        print(f"removed: {removed}", flush=True)
+
+
+def _ensure_emulation_api_placeholder(fern_dir: Path) -> None:
+    """Keep unauthenticated local checks usable without generated library MDX.
+
+    Fern's `folder:` entry in ``index.yml`` points inside the ``output.path``
+    tree of the ``hololink-emulation`` library (see
+    ``docs/user_guide/fern/docs.yml``) -- specifically at the deep subtree
+    ``hololink/namespaces/emulation`` where Fern's C++ generator writes the
+    per-compound MDX (see the comment on the ``folder:`` entry in
+    ``docs/user_guide/fern/index.yml`` for why that path). Fern errors with
+    "Folder not found" if that path does not exist on disk, which is exactly
+    what happens on an unauthenticated local preview where
+    ``fern docs md generate`` never ran (no token) and therefore never wrote
+    anything under ``output.path``. This writes one hidden placeholder MDX
+    file at that folder so the folder always resolves.
+    """
+    # Must mirror the `folder:` target in index.yml exactly; otherwise the
+    # placeholder would land at a different folder than the one Fern probes.
+    output = (
+        fern_dir
+        / "generated"
+        / "api-reference"
+        / "cpp"
+        / "emulation"
+        / "hololink"
+        / "namespaces"
+        / "emulation"
+    )
+    if any(output.rglob("*.mdx")) if output.is_dir() else False:
+        return
+    # Filename prefix `_` and `hidden: true` frontmatter both keep this out of
+    # the rendered sidebar; belt-and-suspenders in case either exclusion
+    # mechanism changes in a future Fern release.
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "_placeholder.mdx").write_text(
+        "---\ntitle: Emulation API\nhidden: true\n---\n\n"
+        "This API reference is generated during authenticated Fern builds.\n",
+        encoding="utf-8",
+    )
+
+
+def _has_generated_emulation_api(fern_dir: Path) -> bool:
+    output = fern_dir / "generated" / "api-reference" / "cpp" / "emulation"
+    if not output.is_dir():
+        return False
+    return any(
+        path.is_file() and path.name not in {"overview.mdx", "_placeholder.mdx"}
+        for path in output.rglob("*.mdx")
+    )
+
+
 def _fern_assets_ok(fern_dir: Path) -> bool:
     dist = fern_dir / "dist"
     return (dist / "output.css").is_file() and (dist / "output.js").is_file()
@@ -411,6 +481,7 @@ def _fern_assets_ok(fern_dir: Path) -> bool:
 
 def run_pipeline(args: argparse.Namespace) -> int:
     fern_dir = args.fern_dir.expanduser().resolve()
+    generated_docs = fern_dir / "generated"
 
     if not SOURCE.is_dir():
         print(f"Missing source dir: {SOURCE}", file=sys.stderr)
@@ -430,6 +501,41 @@ def run_pipeline(args: argparse.Namespace) -> int:
     rc = _check_source_assets(allow_lfs_pointers=args.allow_lfs_pointers)
     if rc:
         return rc
+
+    if args.with_library_mdx:
+        fern_exe = _fern_exe()
+        if not fern_exe:
+            print(
+                "The `fern` CLI was not found on PATH; install it or omit --with-library-mdx.",
+                file=sys.stderr,
+            )
+            return 127
+        if not FIX_LIBRARY_MDX.is_file():
+            print(f"Missing post-process script: {FIX_LIBRARY_MDX}", file=sys.stderr)
+            return 2
+        _clean_generated_api_docs(generated_docs)
+        _run([fern_exe, "docs", "md", "generate"], cwd=fern_dir)
+
+    if generated_docs.is_dir():
+        if not FIX_LIBRARY_MDX.is_file():
+            print(f"Missing post-process script: {FIX_LIBRARY_MDX}", file=sys.stderr)
+            return 2
+        _run(
+            [
+                sys.executable,
+                str(FIX_LIBRARY_MDX),
+                "--root",
+                str(generated_docs),
+            ]
+        )
+
+    if args.publish and not _has_generated_emulation_api(fern_dir):
+        print(
+            "error: production publication requires generated Emulation C++ API pages; "
+            "run with --with-library-mdx.",
+            file=sys.stderr,
+        )
+        return 1
 
     needs_remote_publish = args.publish_preview or args.delete_preview_id or args.publish
     if needs_remote_publish:
@@ -492,6 +598,8 @@ def run_pipeline(args: argparse.Namespace) -> int:
     if not fern_exe:
         print("The `fern` CLI was not found on PATH.", file=sys.stderr)
         return 127
+
+    _ensure_emulation_api_placeholder(fern_dir)
 
     if args.preview:
         return _run_preview(fern_exe, fern_dir, port=args.port)
@@ -673,6 +781,10 @@ def _run_in_docker(args: argparse.Namespace) -> int:
     pipeline_args.append("--skip-lfs-pull")
     if args.allow_lfs_pointers:
         pipeline_args.append("--allow-lfs-pointers")
+    if args.with_library_mdx:
+        pipeline_args.append("--with-library-mdx")
+    if args.skip_library_mdx:
+        pipeline_args.append("--skip-library-mdx")
     if args.skip_fern_check:
         pipeline_args.append("--skip-fern-check")
     if args.preview:
@@ -702,10 +814,10 @@ def _run_in_docker(args: argparse.Namespace) -> int:
     if os.environ.get("CI"):
         docker_env.append("-eCI=1")
     # Forward an explicitly-provided FERN_TOKEN (a non-expiring org token from
-    # `fern token`) for org operations (docs publish). The cached `fern login`
-    # credential is shared into the container via the mounted ~/.fern; it is not injected
-    # as FERN_TOKEN because Fern reads FERN_TOKEN first and an OAuth login access token is
-    # not a valid API token, which would break auth.
+    # `fern token`) for org operations (library generation and docs publish). The cached
+    # `fern login` credential is shared into the container via the mounted ~/.fern; it is
+    # not injected as FERN_TOKEN because Fern reads FERN_TOKEN first and an OAuth login
+    # access token is not a valid API token, which would break auth.
     env_token = _env_fern_token()
     if env_token:
         docker_env.append(f"-eFERN_TOKEN={env_token}")
@@ -789,6 +901,16 @@ def main() -> int:
         help="Do not run ``git lfs pull`` before validating image assets.",
     )
     parser.add_argument(
+        "--with-library-mdx",
+        action="store_true",
+        help="Generate the Emulation C++ API MDX (requires Fern auth).",
+    )
+    parser.add_argument(
+        "--skip-library-mdx",
+        action="store_true",
+        help="Skip C++ API generation even when a Fern org token is available.",
+    )
+    parser.add_argument(
         "--skip-fern-check",
         action="store_true",
         help="Run the pipeline only; skip fern check / preview.",
@@ -860,6 +982,20 @@ def main() -> int:
         if args.no_docker:
             return run_fern_login(args)
         return _run_fern_login_in_docker(args)
+
+    if args.skip_library_mdx:
+        args.with_library_mdx = False
+    elif not args.with_library_mdx:
+        # CI preview and production jobs provide an org token. Generate there
+        # automatically while keeping unauthenticated local checks non-interactive.
+        args.with_library_mdx = _has_fern_org_token()
+
+    if args.with_library_mdx and not _fern_auth_token():
+        print(
+            "error: C++ API generation requires Fern auth (run 'fern login' or set FERN_TOKEN).",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.no_docker:
         return run_pipeline(args)

--- a/docs/scripts/fix_generated_library_mdx.py
+++ b/docs/scripts/fix_generated_library_mdx.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Post-process C++ library MDX emitted by ``fern docs md generate``."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+PARAMFIELD_TYPE = re.compile(
+    r'(<ParamField\b[^>]*?\btype=")([^"]*)(")',
+    flags=re.DOTALL,
+)
+_AMPERSAND_ESCAPE = re.compile(
+    r"&(?!amp;|lt;|gt;|quot;|apos;|#(?:[0-9]{1,7}|[xX][0-9A-Fa-f]{1,6});)"
+)
+_DEFAULT_STRING_LITERAL = re.compile(r'default=""([^"]*)""')
+_UNFIXED_CPP_STRING_DEFAULT = re.compile(r'\bdefault=""')
+_DESCRIPTION_LINE = re.compile(r'^(description:\s*")(.*)("\s*)$')
+_FENCE_BLOCK = re.compile(r"^```[^\n]*\n[\s\S]*?^```\s*$", re.MULTILINE)
+
+
+def fix_line(line: str) -> str:
+    def replace_type(match: re.Match[str]) -> str:
+        prefix, value, suffix = match.groups()
+        return prefix + _AMPERSAND_ESCAPE.sub("&amp;", value) + suffix
+
+    return PARAMFIELD_TYPE.sub(replace_type, line)
+
+
+def _fix_description_line(line: str) -> str:
+    raw = line.rstrip("\r\n")
+    ending = line[len(raw) :]
+    match = _DESCRIPTION_LINE.match(raw)
+    if not match:
+        return line
+    prefix, body, suffix = match.groups()
+    body = (
+        body.replace("&lt;", "\x00lt\x00")
+        .replace("&gt;", "\x00gt\x00")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\x00lt\x00", "&lt;")
+        .replace("\x00gt\x00", "&gt;")
+    )
+    return prefix + body + suffix + ending
+
+
+def _fix_html_comments(text: str) -> str:
+    def replace_comment(match: re.Match[str]) -> str:
+        body = match.group(1).replace("*/", "* /")
+        return "" if "{" in body or "}" in body else "{/* " + body + " */}"
+
+    chunks: list[str] = []
+    position = 0
+    for fence in _FENCE_BLOCK.finditer(text):
+        chunks.append(
+            re.sub(
+                r"<!--([\s\S]*?)-->",
+                replace_comment,
+                text[position : fence.start()],
+            )
+        )
+        chunks.append(fence.group(0))
+        position = fence.end()
+    chunks.append(re.sub(r"<!--([\s\S]*?)-->", replace_comment, text[position:]))
+    return "".join(chunks)
+
+
+def fix_file_content(text: str) -> str:
+    text = _fix_html_comments(text)
+    text = re.sub(r"<br\s*/?\s*>", "<br />", text, flags=re.IGNORECASE)
+    text = _DEFAULT_STRING_LITERAL.sub(
+        lambda match: "default='\"" + match.group(1) + "\"'",
+        text,
+    )
+    lines = [_fix_description_line(line) for line in text.splitlines(keepends=True)]
+    return "".join(fix_line(line) for line in lines)
+
+
+def remove_library_overviews(root: Path) -> int:
+    """Drop Fern's per-library overview.mdx so it does not appear in the sidebar."""
+    removed = 0
+    for path in sorted(root.rglob("overview.mdx")):
+        path.unlink()
+        removed += 1
+        print(f"fix-generated-library-mdx: removed {path.relative_to(root)}")
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "user_guide" / "fern" / "generated",
+    )
+    args = parser.parse_args()
+    root = args.root.expanduser().resolve()
+    if not root.is_dir():
+        print(f"error: generated MDX directory does not exist: {root}", file=sys.stderr)
+        return 1
+
+    remove_library_overviews(root)
+
+    changed = 0
+    errors: list[str] = []
+    for path in sorted(root.rglob("*.mdx")):
+        text = path.read_text(encoding="utf-8")
+        fixed = fix_file_content(text)
+        if fixed != text:
+            path.write_text(fixed, encoding="utf-8")
+            changed += 1
+        for line_number, line in enumerate(fixed.splitlines(), 1):
+            if _UNFIXED_CPP_STRING_DEFAULT.search(line):
+                errors.append(f"{path.relative_to(root)}:{line_number}: {line.strip()}")
+
+    print(f"fix-generated-library-mdx: updated {changed} file(s) under {root}")
+    if errors:
+        print("error: generated MDX still contains invalid C++ string defaults:", file=sys.stderr)
+        for error in errors[:10]:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/user_guide/.gitignore
+++ b/docs/user_guide/.gitignore
@@ -1,3 +1,6 @@
+# C++ API MDX from `fern docs md generate` (see fern/docs.yml)
+fern/generated/
+
 # Fern CLI local state (caches, `fern docs diff` output, etc.)
 fern/.fern/
 

--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -42,7 +42,8 @@ Pass `--skip-fern-check` to run the pipeline only (no Fern validation).
 
 CI publishes remote Fern previews and surfaces the link on merge requests:
 
-- **GitLab CI** (MR with `scope::docs` label): publishes a Fern preview; the MR shows a **View app** link under **Environments** (no extra token required)
+- **GitLab CI** (open MR with documentation changes): publishes a Fern preview from the
+  branch pipeline; the MR shows a **View app** link under **Environments**
 - **GitLab CI** (optional): posts an MR comment with the same link when `GITLAB_HSB_API_TOKEN` or `GITLAB_API_TOKEN` is set in CI/CD variables (same PAT Jenkins uses)
 - **Jenkins merge pipeline** (MR with `scope::docs` label): same preview flow when the Jenkins x86_64 flow runs
 - **GitLab CI** `hololink-user-guide` job: runs `fern check --local` on every pipeline for validation
@@ -66,6 +67,19 @@ fern docs dev
 ```
 
 Or use the build script from the repo root (Docker or `--no-docker`).
+
+## C++ API reference
+
+Fern generates the C++ API reference only from `src/hololink/emulation/`. Generate it
+explicitly with:
+
+```bash
+docs/make_docs.sh --with-library-mdx
+```
+
+This requires Fern authentication. Builds with an explicit `FERN_TOKEN` generate it
+automatically; unauthenticated local checks use a placeholder page instead. Pass
+`--skip-library-mdx` to suppress automatic generation.
 
 ## Publish preview
 

--- a/docs/user_guide/emulation.mdx
+++ b/docs/user_guide/emulation.mdx
@@ -7,6 +7,7 @@
 - [Examples](#examples)
 - [Testing](#testing)
 - [Developing with HSB Emulator](#developing-with-hsb-emulator)
+  - [Making your own HSB MCU](#making-your-own-hsb-mcu)
   - [Primary Classes](#primary-classes)
     - `HSBEmulator`
     - `DataPlane`
@@ -240,6 +241,32 @@ example, using the STM32_Programmer_CLI,
 ```
 
 </Tab>
+<Tab title="Emulator-only for TEMPLATE">
+
+This TEMPLATE target is meant for developing a custom HSB implementation for a real
+hardware target. The provided implementation is intentionally minimal: every required
+symbol is stubbed so the tree compiles with the gcc arm cross compiling toolchain, and a
+target board linker script + peripheral modules (i2c, spi, gpio, etc.) are left for you to
+fill in.
+
+First install the toolchain:
+
+```
+  sudo apt-get install gcc-arm-none-eabi
+```
+
+To build:
+
+```
+  mkdir build
+  cmake -S src/hololink/emulation -B build -DHSB_EMULATOR_TARGET=TEMPLATE -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/arm-none-eabi-gcc.cmake
+  cmake --build build -j
+```
+
+An `.elf` will be produced but it does nothing useful yet. See
+[Making your own HSB MCU](#making-your-own-hsb-mcu) for the per-function quick-start.
+
+</Tab>
 </Tabs>
 
 ### Configuring the Emulator-only build
@@ -421,6 +448,67 @@ SIPL example for vb1940 through the MGBE port with CoE offloading.
 
 ## Developing with HSB Emulator
 
+### Making your own HSB MCU
+
+The `TEMPLATE` target is the starting point for porting HSB to a new MCU. It builds, but
+every function is a stub — your job is to plug in the platform-specific logic.
+
+1. **Source layout** — three files under `src/hololink/emulation/src/Template/` provide
+   everything you need to extend:
+   - `HSBTemplate.cpp` — control-plane handling, BootP broadcasting, basic networking.
+   - `HSBTemplate_rocev2.cpp` — RoCEv2 transmit path (ConnectX-compatible).
+   - `HSBTemplate_coe.cpp` — IEEE 1722B Camera-over-Ethernet transmit path (SIPL / FuSa on
+     AGX Thor and IGX Thor Mini with mGbE).
+
+2. **Find every `TODO`** in the three files above and fill it in. The functions that
+   actually need platform work are grouped by concern:
+
+   *Networking / control plane*
+   - `IPAddress_from_string` — populate the `IPAddress` struct (MAC, `if_name`, subnet
+     mask, broadcast) from dotted-quad text.
+   - `control_plane_reply` — put a pre-built scatter/gather ECB reply on the wire.
+   - `HSBEmulator::handle_msgs` — receive and dispatch ECB packets to
+     `handle_control_packet`; optionally also drive other required networking tasks (ICMP /
+     ARP / BootP) if single-threaded and no networking middleware (see STM32's
+     implementation).
+   - `HSBEmulator::add_data_plane` — track a DataPlane so it gets `start()` / `stop()`
+     lifecycle calls.
+   - `HSBEmulator::HSBEmulator` — register per-control plane register callbacks with
+     `HSBEmulator::register_read_callback` and `HSBEmulator::register_write_callback`
+
+   *Transmit paths*
+   - `send_coe_packet` — emit a 1722B frame from a scatter/gather array.
+   - `send_rocev2_packet` — emit a RoCEv2 frame from a scatter/gather array.
+
+   *DataPlane BootP and task timing*
+   - `clock_gettime` — used to stamp BootP `secs` and frame metadata timestamps.
+   - `DataPlane::broadcast_bootp` — put one BootP packet on the wire. Wrap in a thread /
+     RTOS task if your runtime is multi-threaded.
+   - `DataPlane::DataPlane` — register per-DataPlane/Sensor register callbacks with
+     `HSBEmulator::register_read_callback` and `HSBEmulator::register_write_callback`
+
+   *Main-loop timing helpers (only if you run the bundled `serve_*_msg` examples)*
+   - `msleep(unsigned)` — millisecond sleep used by `serve_coe_msg` / `serve_roce_msg` to
+     throttle to `FRAME_RATE`.
+
+3. **Functions you can usually leave alone.** Anything that exists purely to coordinate
+   concurrency (mutexes, condition variables, atomic flags) can stay as the empty stub when
+   your runtime is single-threaded. Threading hooks are there to *accommodate* a
+   multi-threaded port, not to require one.
+
+4. **Carrying your own state.** Each control-plane / data-plane object holds a `*Ctxt`
+   struct (e.g. `HSBEmulatorCtxt`, `DataPlaneCtxt`, `COECtxt`, `RoCEv2Ctxt`). Extend the
+   appropriate one with whatever per-instance fields your platform needs (DMA descriptors,
+   HAL handles, ring buffers). Lifetime is yours to manage — the framework only holds a
+   `Ctxt*`.
+
+5. **implement your own target** and customize the target build.
+   - Copy your new implementation files out/rename the folder and the corresponding target
+     `.cmake` file in `cmake/targets/`.
+   - Add the new target name to the `HSB_EMULATOR_EMBEDDED_TARGETS` list in the
+     `src/hololink/emulation/CMakeLists.txt` file to enable a new target alongside
+     `STM32F767ZI` and `TEMPLATE`.
+
 ### Primary Classes
 
 For all the classes below, the C++ namespace is assumed `hololink::emulation` and the
@@ -428,6 +516,9 @@ Python module is loaded as `import hololink.emulation as hemu`. Python-equivalen
 examples or definitions are given for clarity for non-trivial signatures. For further
 details including private and protected members of classes for development purposes, see
 the source code in `src/hololink/emulation`.
+
+For detailed API documentation of the HSB Emulator interface, see the
+[Emulation API reference](/holoscan/sensor-bridge/api-reference/emulation-api).
 
 The HSB Emulator class is used for command and control communication between the
 Emulator device and the Host HSB Application

--- a/docs/user_guide/fern/docs.yml
+++ b/docs/user_guide/fern/docs.yml
@@ -1,5 +1,32 @@
 # yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
 
+# Generate only the emulator's public C++ API. Scope is restricted to the
+# top-level headers of `src/hololink/emulation` (the emulator HAL interface) by
+# `emulation.Doxyfile` (INPUT + RECURSIVE = NO), so implementation / build /
+# example / binding subdirectories are not parsed. The build helper post-
+# processes the generated MDX before Fern validates, previews, or publishes it.
+#
+# Library key `hololink-emulation` is deliberately NOT `hololink`: this entry
+# documents the `hololink::emulation` sub-namespace as a standalone API-reference
+# section, not the whole `hololink` library. Future top-level `hololink` C++ API
+# docs will be a separate `libraries:` entry (with its own subpath, once the
+# public headers move out of `src/hololink/emulation`). One consequence: Fern's
+# C++ generator only emits Stage-4 namespace index pages when the library key
+# matches a top-level C++ namespace name -- since ours does not, we get just
+# the per-compound pages (classes / functions / enums / typedefs / variables)
+# and the `Emulation API` folder in `index.yml` takes the place of a landing
+# page for the section.
+libraries:
+  hololink-emulation:
+    input:
+      git: https://github.com/nvidia-holoscan/holoscan-sensor-bridge.git
+      subpath: src/hololink/emulation
+    output:
+      path: ./generated/api-reference/cpp/emulation
+    lang: cpp
+    config:
+      doxyfile: ./emulation.Doxyfile
+
 instances:
   - url: nvidia-holoscan.docs.buildwithfern.com/holoscan/sensor-bridge
     custom-domain: docs.nvidia.com/holoscan/sensor-bridge

--- a/docs/user_guide/fern/emulation.Doxyfile
+++ b/docs/user_guide/fern/emulation.Doxyfile
@@ -1,0 +1,69 @@
+# Doxyfile for Fern's C++ library docs generator (`fern docs md generate`).
+#
+# Fern's C++ parser (`fernenterprise/fern-cpp-library-docs-parser`) uses this
+# file's CONTENTS **verbatim** when `config.doxyfile:` is set in docs.yml -- it
+# writes them to the parser workdir as `Doxyfile`, appends a single
+# `OUTPUT_DIRECTORY = ...` line, and runs `doxygen Doxyfile` with cwd set to
+# the (writable copy of the) mounted repo root. Its own default template
+# (INPUT/RECURSIVE/EXTRACT_ALL/EXCLUDE_PATTERNS/FILE_PATTERNS/etc.) is NOT
+# layered on top. Any Doxygen setting we care about must therefore be listed
+# here explicitly; unset settings fall back to Doxygen's own defaults from
+# `doxygen -g`, NOT to the parser's template.
+#
+# Concretely, the parser used to set (with `packagePath = src/hololink/emulation`):
+#   INPUT      = /repo-copy/src/hololink/emulation
+#   RECURSIVE  = YES
+#   EXTRACT_ALL = YES
+#   FILE_PATTERNS = *.h *.hpp *.hxx ... (broad list)
+# When we supply this Doxyfile, ALL of that is dropped -- so we must re-supply
+# INPUT (Doxygen defaults it to `.`, which under the parser's cwd is the whole
+# repo copy) and FILE_PATTERNS (Doxygen's `-g` defaults omit `.hpp`, silently
+# dropping every emulation header).
+
+# --- Output: Fern reads Doxygen's XML index; HTML/LaTeX are dead weight. ---
+GENERATE_XML   = YES
+GENERATE_HTML  = NO
+GENERATE_LATEX = NO
+
+# --- Scope: emulation public headers only. ---------------------------------
+# INPUT is relative to Doxygen's cwd, which the parser sets to the repo root.
+# Combined with `RECURSIVE = NO`, this restricts extraction to the header
+# files directly under EACH listed directory (Doxygen scans every INPUT entry
+# non-recursively, so listing `sensors/` explicitly picks up the sensor
+# emulator headers without pulling in any deeper subdirectory). The other
+# emulation subdirectories -- cmake/, examples/, python/, src/ -- are
+# implementation / build / binding trees and stay excluded because they are
+# not listed here.
+#
+# FILE_PATTERNS is restricted to header extensions so we document the public
+# interface surface only, not `.cpp` translation units. `*.hpp` is listed
+# explicitly because Doxygen's stock `-g` defaults omit it in some builds
+# (they cover `*.h *.hh *.hxx *.h++` but not `*.hpp`), which would produce an
+# empty XML index and "generated 0 pages" even with `EXTRACT_ALL = YES`.
+INPUT         = src/hololink/emulation \
+                src/hololink/emulation/sensors
+RECURSIVE     = NO
+FILE_PATTERNS = *.h *.hpp *.hxx *.h++ *.cuh
+
+# `test_sensor.hpp` defines the bench-only `TestSensor` peripheral (plus its
+# `TestPatternMode` enum and `TEST_I2C_ADDRESS` constant); it is compiled
+# into `libihsb` tests but is not part of the shipping emulator API surface,
+# so drop it from the extracted set. The pattern is matched by Doxygen
+# against each file's full path, so a bare basename glob is enough.
+EXCLUDE_PATTERNS = */test_sensor.hpp
+
+# --- Extraction: emit compounds even for headers without doxygen comments. -
+# The emulation headers use plain `//` comments and license blocks, no
+# `///` / `/** @brief */` blocks on classes or functions. Doxygen defaults
+# EXTRACT_ALL to NO, which drops undocumented compounds silently, producing
+# an XML index with zero <compound> elements. Fern's parser then reports
+# "generated 0 pages" and the folder Fern was told to write into never
+# gets created, causing a later "Folder not found" from the publish step.
+# EXTRACT_ALL = YES surfaces every public entity regardless of whether it
+# has a doxygen docstring; private/protected members remain hidden because
+# EXTRACT_PRIVATE keeps its default NO. EXTRACT_STATIC = YES matches the
+# parser's own default so file-scope helpers still show up.
+EXTRACT_ALL          = YES
+EXTRACT_STATIC       = YES
+WARN_IF_UNDOCUMENTED = NO
+QUIET                = YES

--- a/docs/user_guide/fern/generated/api-reference/cpp/core/overview.mdx
+++ b/docs/user_guide/fern/generated/api-reference/cpp/core/overview.mdx
@@ -1,8 +1,0 @@
-______________________________________________________________________
-
-## title: Hololink Core C++ API
-
-This C++ API reference is generated with Fern authentication.
-
-Run `docs/make_docs.sh --with-library-mdx` (requires `fern login` or the `FERN_TOKEN`
-environment variable) to populate this section.

--- a/docs/user_guide/fern/generated/api-reference/cpp/emulation/overview.mdx
+++ b/docs/user_guide/fern/generated/api-reference/cpp/emulation/overview.mdx
@@ -1,8 +1,0 @@
-______________________________________________________________________
-
-## title: Emulation C++ API
-
-This C++ API reference is generated with Fern authentication.
-
-Run `docs/make_docs.sh --with-library-mdx` (requires `fern login` or the `FERN_TOKEN`
-environment variable) to populate this section.

--- a/docs/user_guide/fern/index.yml
+++ b/docs/user_guide/fern/index.yml
@@ -39,6 +39,24 @@ navigation:
       - page: HSB Emulator
         path: ../emulation.mdx
 
+  - section: API reference
+    contents:
+      # Fern's C++ library generator writes MDX at output.path (see
+      # docs.yml `libraries.hololink-emulation.output.path`). Because the
+      # library key (`hololink-emulation`) does NOT equal the top-level C++
+      # namespace (`hololink`), Fern's generator does NOT strip a leading
+      # namespace segment from filesystem paths, so per-compound pages land
+      # nested under `hololink/namespaces/emulation/{classes,functions,...}`.
+      # Pointing `folder:` at THAT deep subtree (rather than at the shallower
+      # output.path) makes Fern's nav walker skip the redundant
+      # `hololink -> namespaces -> emulation` breadcrumb and surface just the
+      # {classes, functions, enums} groups under `Emulation API`. Fern's
+      # `folder:` walk is recursive and picks up every generated .mdx below.
+      - folder: ./generated/api-reference/cpp/emulation/hololink/namespaces/emulation
+        title: Emulation API
+        slug: emulation-api
+        collapsed: true
+
   - section: FPGA IP
     contents:
       - page: Overview

--- a/docs/user_guide/setup.mdx
+++ b/docs/user_guide/setup.mdx
@@ -152,15 +152,17 @@ In summary, the host network interface associated with `$IN0` (`roceP5p3s0f0`) i
 - IGX OS uses NetworkManager to configure network interfaces. By default, the sensor
   bridge device uses the address 192.168.0.2 for the first port. Set up your first
   ethernet device (`$EN0`) to use the address 192.168.0.101 with a permanent route to
-  192.168.0.2: ([Here](notes.mdx#holoscan-sensor-bridge-ip-address-configuration) is
-  more information about configuring your system if you cannot use the 192.168.0.0/24
+  192.168.0.2 using the
+  [recommended MTU](https://enterprise-support.nvidia.com/s/article/mtu-considerations-for-roce-based-applications)
+  for use with RoCE: ([Here](notes.mdx#holoscan-sensor-bridge-ip-address-configuration)
+  is more information about configuring your system if you cannot use the 192.168.0.0/24
   network in this way.)
 
 ```none
   sudo nmcli con add con-name hololink-$EN0 ifname $EN0 type ethernet ip4 192.168.0.101/24
   sudo nmcli connection modify hololink-$EN0 +ipv4.routes 192.168.0.2/32
   sudo nmcli connection modify hololink-$EN0 ethtool.ring-rx 4096
-  sudo nmcli connection modify hololink-$EN0 802-3-ethernet.mtu 4096
+  sudo nmcli connection modify hololink-$EN0 802-3-ethernet.mtu 4200
   sudo nmcli connection up hololink-$EN0
 ```
 
@@ -210,7 +212,7 @@ with an appropriate address and permanent route:
   sudo nmcli con add con-name hololink-$EN1 ifname $EN1 type ethernet ip4 192.168.0.102/24
   sudo nmcli connection modify hololink-$EN1 +ipv4.routes 192.168.0.3/32
   sudo nmcli connection modify hololink-$EN1 ethtool.ring-rx 4096
-  sudo nmcli connection modify hololink-$EN1 802-3-ethernet.mtu 4096
+  sudo nmcli connection modify hololink-$EN1 802-3-ethernet.mtu 4200
   sudo nmcli connection up hololink-$EN1
 ```
 
@@ -299,21 +301,22 @@ bridge code.
 - Run the "jetson_clocks" tool on startup, to set the core clocks to their maximum.
 
 ```none
-  JETSON_CLOCKS_SERVICE=/etc/systemd/system/jetson_clocks.service
-  cat <<EOF | sudo tee $JETSON_CLOCKS_SERVICE >/dev/null
-  [Unit]
-  Description=Jetson Clocks Startup
-  After=nvpmodel.service
+JETSON_CLOCKS_SERVICE=/etc/systemd/system/jetson_clocks.service
+cat <<EOF | sudo tee $JETSON_CLOCKS_SERVICE >/dev/null
+[Unit]
+Description=Jetson Clocks Startup
+After=nvpmodel.service
    
-  [Service]
-  Type=oneshot
-  ExecStart=/usr/bin/jetson_clocks
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/jetson_clocks
    
-  [Install]
-  WantedBy=multi-user.target
-  EOF
-  sudo chmod u+x $JETSON_CLOCKS_SERVICE
-  sudo systemctl enable jetson_clocks.service
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo chmod u+x $JETSON_CLOCKS_SERVICE
+sudo systemctl enable jetson_clocks.service
 ```
 
 - Set the AGX Orin power mode to 'MAXN' for optimal performance. The setting can be
@@ -392,15 +395,17 @@ In summary, the host network interface associated with `$IN0` (`roceP2p1s0f0`) i
 - DGX OS uses NetworkManager to configure network interfaces. By default, the sensor
   bridge device uses the address 192.168.0.2 for the first port. Set up your first
   ethernet device (`$EN0`) to use the address 192.168.0.101 with a permanent route to
-  192.168.0.2: ([Here](notes.mdx#holoscan-sensor-bridge-ip-address-configuration) is
-  more information about configuring your system if you cannot use the 192.168.0.0/24
+  192.168.0.2 using the
+  [recommended MTU](https://enterprise-support.nvidia.com/s/article/mtu-considerations-for-roce-based-applications)
+  for use with RoCE: ([Here](notes.mdx#holoscan-sensor-bridge-ip-address-configuration)
+  is more information about configuring your system if you cannot use the 192.168.0.0/24
   network in this way.)
 
 ```none
   sudo nmcli con add con-name hololink-$EN0 ifname $EN0 type ethernet ip4 192.168.0.101/24
   sudo nmcli connection modify hololink-$EN0 +ipv4.routes 192.168.0.2/32
   sudo nmcli connection modify hololink-$EN0 ethtool.ring-rx 4096
-  sudo nmcli connection modify hololink-$EN0 802-3-ethernet.mtu 4096
+  sudo nmcli connection modify hololink-$EN0 802-3-ethernet.mtu 4200
   sudo nmcli connection up hololink-$EN0
 ```
 
@@ -448,7 +453,7 @@ with an appropriate address and permanent route:
   sudo nmcli con add con-name hololink-$EN1 ifname $EN1 type ethernet ip4 192.168.0.102/24
   sudo nmcli connection modify hololink-$EN1 +ipv4.routes 192.168.0.3/32
   sudo nmcli connection modify hololink-$EN1 ethtool.ring-rx 4096
-  sudo nmcli connection modify hololink-$EN1 802-3-ethernet.mtu 4096
+  sudo nmcli connection modify hololink-$EN1 802-3-ethernet.mtu 4200
   sudo nmcli connection up hololink-$EN1
 ```
 

--- a/scripts/nsisolate.sh
+++ b/scripts/nsisolate.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # This is a convenience script used by pytest hw_loopback session fixture in tests/conftest.py to isolate an interface into a network namespace with the provided IPV4 address
-# For use cases, see https://docs.nvidia/com/holoscan/sensor-bridge/latest/emulation.html#testing
+# For use cases, see https://docs.nvidia.com/holoscan/sensor-bridge/emulation/hsb-emulator#testing
 
 if [ $# -lt 1 ] ; then
 	echo "Usage: $0 <if_name> [<ipv4>]"

--- a/src/hololink/emulation/address_memory.hpp
+++ b/src/hololink/emulation/address_memory.hpp
@@ -77,8 +77,10 @@ public:
     /**
      * @brief Write a range of values to registers. Allow optimizations if it is known that the addresses are contiguous.
      *
-     * @param address_values Pointer to array of pairs of register addresses and values to write (caller must allocate at least num_addresses elements)
-     * @param num_addresses The number of addresses to write
+     * @param start_address The first register address in the range.
+     * @param values Pointer to the array of values to write (caller must allocate at least num_addresses elements).
+     * @param num_addresses The number of addresses to write.
+     * @param stride The address increment between consecutive registers in the range (defaults to 2).
      * @return 0 on success, 1 on failure
      */
     virtual int write_range(uint32_t start_address, uint32_t* values, int num_addresses, int stride = 2) = 0;
@@ -86,8 +88,10 @@ public:
     /**
      * @brief Read a range of values from registers. Allow optimizations if it is known that the addresses are contiguous.
      *
-     * @param address_values Pointer to array of pairs of register addresses and values to read (caller must allocate at least num_addresses elements)
-     * @param num_addresses The number of addresses to read
+     * @param start_address The first register address in the range.
+     * @param values Pointer to the array that receives the values read (caller must allocate at least num_addresses elements).
+     * @param num_addresses The number of addresses to read.
+     * @param stride The address increment between consecutive registers in the range (defaults to 2).
      * @return 0 on success, 1 on failure
      */
     virtual int read_range(uint32_t start_address, uint32_t* values, int num_addresses, int stride = 2) = 0;


### PR DESCRIPTION
emulator TEMPLATE build and API documentation was incompatible with fern migration. Re-adding back to main.
Update MTU info and jetson clocks setup in host setup documentation where syntax errors were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional generation of the Emulation C++ API reference for Fern documentation.
  * Added navigation and API reference pages for generated Emulation documentation.
  * Added guidance for creating a custom HSB MCU.
* **Documentation**
  * Updated Fern authentication and preview workflow instructions.
  * Clarified C++ API generation requirements and local validation behavior.
  * Improved network setup guidance, including the recommended 4200 MTU.
* **Bug Fixes**
  * Corrected generated API formatting and documentation links.
  * Corrected parameter descriptions for emulation memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->